### PR TITLE
Scale inertias

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+/robot/millihex_description.urdf

--- a/config/millihex_control.yaml
+++ b/config/millihex_control.yaml
@@ -2,90 +2,90 @@ millihex:
     # Publish all joint states -----------------------------------
     joint_state_controller:
         type: joint_state_controller/JointStateController
-        publish_rate: 50
+        publish_rate: 100
 
     # Joint position controllers ---------------------------------------
     # Leg 1
     leg1_joint1_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg1_joint1
-        pid: {p: 0.2, i: 0.0, d: 0.0}
+        pid: {p: 0.1, i: 0.0, d: 8.03e-05}
     leg1_joint2_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg1_joint2
-        pid: {p: 0.2, i: 0.0, d: 0.0}
+        pid: {p: 0.1, i: 0.0, d: 8.03e-05}
     leg1_joint3_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg1_joint3
-        pid: {p: 0.2, i: 0.0, d: 0.0}
+        pid: {p: 0.1, i: 0.0, d: 8.03e-05}
 
     # Leg 2
     leg2_joint1_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg2_joint1
-        pid: {p: 0.2, i: 0.0, d: 0.0}
+        pid: {p: 0.1, i: 0.0, d: 8.03e-05}
     leg2_joint2_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg2_joint2
-        pid: {p: 0.2, i: 0.0, d: 0.0}
+        pid: {p: 0.1, i: 0.0, d: 8.03e-05}
     leg2_joint3_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg2_joint3
-        pid: {p: 0.2, i: 0.0, d: 0.0}
+        pid: {p: 0.1, i: 0.0, d: 8.03e-05}
 
     # Leg 3
     leg3_joint1_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg3_joint1
-        pid: {p: 0.2, i: 0.0, d: 0.0}
+        pid: {p: 0.1, i: 0.0, d: 8.03e-05}
     leg3_joint2_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg3_joint2
-        pid: {p: 0.2, i: 0.0, d: 0.0}
+        pid: {p: 0.1, i: 0.0, d: 8.03e-05}
     leg3_joint3_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg3_joint3
-        pid: {p: 0.2, i: 0.0, d: 0.0}
+        pid: {p: 0.1, i: 0.0, d: 8.03e-05}
 
     # Leg 4
     leg4_joint1_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg4_joint1
-        pid: {p: 0.2, i: 0.0, d: 0.0}
+        pid: {p: 0.1, i: 0.0, d: 8.03e-05}
     leg4_joint2_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg4_joint2
-        pid: {p: 0.2, i: 0.0, d: 0.0}
+        pid: {p: 0.1, i: 0.0, d: 8.03e-05}
     leg4_joint3_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg4_joint3
-        pid: {p: 0.2, i: 0.0, d: 0.0}
+        pid: {p: 0.1, i: 0.0, d: 8.03e-05}
 
     # Leg 5
     leg5_joint1_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg5_joint1
-        pid: {p: 0.2, i: 0.0, d: 0.0}
+        pid: {p: 0.1, i: 0.0, d: 8.03e-05}
     leg5_joint2_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg5_joint2
-        pid: {p: 0.2, i: 0.0, d: 0.0}
+        pid: {p: 0.1, i: 0.0, d: 8.03e-05}
     leg5_joint3_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg5_joint3
-        pid: {p: 0.2, i: 0.0, d: 0.0}
+        pid: {p: 0.1, i: 0.0, d: 8.03e-05}
 
     # Leg 6
     leg6_joint1_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg6_joint1
-        pid: {p: 0.2, i: 0.0, d: 0.0}
+        pid: {p: 0.1, i: 0.0, d: 8.03e-05}
     leg6_joint2_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg6_joint2
-        pid: {p: 0.2, i: 0.0, d: 0.0}
+        pid: {p: 0.1, i: 0.0, d: 8.03e-05}
     leg6_joint3_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg6_joint3
-        pid: {p: 0.2, i: 0.0, d: 0.0}
+        pid: {p: 0.1, i: 0.0, d: 8.03e-05}
 

--- a/config/millihex_control.yaml
+++ b/config/millihex_control.yaml
@@ -9,83 +9,83 @@ millihex:
     leg1_joint1_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg1_joint1
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.2, i: 0.0, d: 0.0}
     leg1_joint2_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg1_joint2
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.2, i: 0.0, d: 0.0}
     leg1_joint3_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg1_joint3
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.2, i: 0.0, d: 0.0}
 
     # Leg 2
     leg2_joint1_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg2_joint1
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.2, i: 0.0, d: 0.0}
     leg2_joint2_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg2_joint2
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.2, i: 0.0, d: 0.0}
     leg2_joint3_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg2_joint3
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.2, i: 0.0, d: 0.0}
 
     # Leg 3
     leg3_joint1_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg3_joint1
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.2, i: 0.0, d: 0.0}
     leg3_joint2_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg3_joint2
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.2, i: 0.0, d: 0.0}
     leg3_joint3_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg3_joint3
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.2, i: 0.0, d: 0.0}
 
     # Leg 4
     leg4_joint1_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg4_joint1
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.2, i: 0.0, d: 0.0}
     leg4_joint2_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg4_joint2
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.2, i: 0.0, d: 0.0}
     leg4_joint3_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg4_joint3
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.2, i: 0.0, d: 0.0}
 
     # Leg 5
     leg5_joint1_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg5_joint1
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.2, i: 0.0, d: 0.0}
     leg5_joint2_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg5_joint2
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.2, i: 0.0, d: 0.0}
     leg5_joint3_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg5_joint3
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.2, i: 0.0, d: 0.0}
 
     # Leg 6
     leg6_joint1_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg6_joint1
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.2, i: 0.0, d: 0.0}
     leg6_joint2_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg6_joint2
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.2, i: 0.0, d: 0.0}
     leg6_joint3_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg6_joint3
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.2, i: 0.0, d: 0.0}
 

--- a/config/millihex_control.yaml
+++ b/config/millihex_control.yaml
@@ -4,7 +4,7 @@ millihex:
         type: joint_state_controller/JointStateController
         publish_rate: 50
 
-    # Position Controllers ---------------------------------------
+    # Joint position controllers ---------------------------------------
     # Leg 1
     leg1_joint1_position_controller:
         type: effort_controllers/JointPositionController

--- a/config/millihex_control.yaml
+++ b/config/millihex_control.yaml
@@ -9,96 +9,96 @@ millihex:
   leg1_joint1_position_controller:
     type: effort_controllers/JointPositionController
     joint: leg1_joint1
-    pid: {p: 0.1, i: 0.0, d: 0.0}
+    pid: {p: 0.05, i: 0.0, d: 0.0}
 
   leg1_joint2_position_controller:
     type: effort_controllers/JointPositionController
     joint: leg1_joint2
-    pid: {p: 0.1, i: 0.0, d: 0.0}
+    pid: {p: 0.2, i: 0.0, d: 0.0}
 
   leg1_joint3_position_controller:
     type: effort_controllers/JointPositionController
     joint: leg1_joint3
-    pid: {p: 0.1, i: 0.0, d: 0.0}
+    pid: {p: 0.2, i: 0.0, d: 0.0}
 
   # Leg 2
   leg2_joint1_position_controller:
     type: effort_controllers/JointPositionController
     joint: leg2_joint1
-    pid: {p: 0.1, i: 0.0, d: 0.0}
+    pid: {p: 0.2, i: 0.0, d: 0.0}
 
   leg2_joint2_position_controller:
     type: effort_controllers/JointPositionController
     joint: leg2_joint2
-    pid: {p: 0.1, i: 0.0, d: 0.0}
+    pid: {p: 0.2, i: 0.0, d: 0.0}
 
   leg2_joint3_position_controller:
     type: effort_controllers/JointPositionController
     joint: leg2_joint3
-    pid: {p: 0.1, i: 0.0, d: 0.0}
+    pid: {p: 0.2, i: 0.0, d: 0.0}
 
   # Leg 3
   leg3_joint1_position_controller:
     type: effort_controllers/JointPositionController
     joint: leg3_joint1
-    pid: {p: 0.1, i: 0.0, d: 0.0}
+    pid: {p: 0.2, i: 0.0, d: 0.0}
 
   leg3_joint2_position_controller:
     type: effort_controllers/JointPositionController
     joint: leg3_joint2
-    pid: {p: 0.1, i: 0.0, d: 0.0}
+    pid: {p: 0.2, i: 0.0, d: 0.0}
 
   leg3_joint3_position_controller:
     type: effort_controllers/JointPositionController
     joint: leg3_joint3
-    pid: {p: 0.1, i: 0.0, d: 0.0}
+    pid: {p: 0.2, i: 0.0, d: 0.0}
 
   # Leg 4
   leg4_joint1_position_controller:
     type: effort_controllers/JointPositionController
     joint: leg4_joint1
-    pid: {p: 0.1, i: 0.0, d: 0.0}
+    pid: {p: 0.2, i: 0.0, d: 0.0}
 
   leg4_joint2_position_controller:
     type: effort_controllers/JointPositionController
     joint: leg4_joint2
-    pid: {p: 0.1, i: 0.0, d: 0.0}
+    pid: {p: 0.2, i: 0.0, d: 0.0}
 
   leg4_joint3_position_controller:
     type: effort_controllers/JointPositionController
     joint: leg4_joint3
-    pid: {p: 0.1, i: 0.0, d: 0.0}
+    pid: {p: 0.2, i: 0.0, d: 0.0}
 
   # Leg 5
   leg5_joint1_position_controller:
     type: effort_controllers/JointPositionController
     joint: leg5_joint1
-    pid: {p: 0.1, i: 0.0, d: 0.0}
+    pid: {p: 0.2, i: 0.0, d: 0.0}
 
   leg5_joint2_position_controller:
     type: effort_controllers/JointPositionController
     joint: leg5_joint2
-    pid: {p: 0.1, i: 0.0, d: 0.0}
+    pid: {p: 0.2, i: 0.0, d: 0.0}
 
   leg5_joint3_position_controller:
     type: effort_controllers/JointPositionController
     joint: leg5_joint3
-    pid: {p: 0.1, i: 0.0, d: 0.0}
+    pid: {p: 0.2, i: 0.0, d: 0.0}
 
   # Leg 6
   leg6_joint1_position_controller:
     type: effort_controllers/JointPositionController
     joint: leg6_joint1
-    pid: {p: 0.1, i: 0.0, d: 0.0}
+    pid: {p: 0.2, i: 0.0, d: 0.0}
 
   leg6_joint2_position_controller:
     type: effort_controllers/JointPositionController
     joint: leg6_joint2
-    pid: {p: 0.1, i: 0.0, d: 0.0}
+    pid: {p: 0.2, i: 0.0, d: 0.0}
 
   leg6_joint3_position_controller:
     type: effort_controllers/JointPositionController
     joint: leg6_joint3
-    pid: {p: 0.1, i: 0.0, d: 0.0}
+    pid: {p: 0.2, i: 0.0, d: 0.0}
 
   # To add more just add them here as the first one

--- a/config/millihex_control.yaml
+++ b/config/millihex_control.yaml
@@ -9,83 +9,83 @@ millihex:
     leg1_joint1_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg1_joint1
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.06, i: 0.0, d: 0.00015}
     leg1_joint2_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg1_joint2
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.06, i: 0.0, d: 0.00015}
     leg1_joint3_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg1_joint3
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.06, i: 0.0, d: 0.00015}
 
     # Leg 2
     leg2_joint1_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg2_joint1
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.06, i: 0.0, d: 0.00015}
     leg2_joint2_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg2_joint2
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.06, i: 0.0, d: 0.00015}
     leg2_joint3_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg2_joint3
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.06, i: 0.0, d: 0.00015}
 
     # Leg 3
     leg3_joint1_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg3_joint1
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.06, i: 0.0, d: 0.00015}
     leg3_joint2_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg3_joint2
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.06, i: 0.0, d: 0.00015}
     leg3_joint3_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg3_joint3
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.06, i: 0.0, d: 0.00015}
 
     # Leg 4
     leg4_joint1_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg4_joint1
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.06, i: 0.0, d: 0.00015}
     leg4_joint2_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg4_joint2
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.06, i: 0.0, d: 0.00015}
     leg4_joint3_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg4_joint3
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.06, i: 0.0, d: 0.00015}
 
     # Leg 5
     leg5_joint1_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg5_joint1
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.06, i: 0.0, d: 0.00015}
     leg5_joint2_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg5_joint2
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.06, i: 0.0, d: 0.00015}
     leg5_joint3_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg5_joint3
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.06, i: 0.0, d: 0.00015}
 
     # Leg 6
     leg6_joint1_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg6_joint1
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.06, i: 0.0, d: 0.00015}
     leg6_joint2_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg6_joint2
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.06, i: 0.0, d: 0.00015}
     leg6_joint3_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg6_joint3
-        pid: {p: 0.1, i: 0.0, d: 0.0}
+        pid: {p: 0.06, i: 0.0, d: 0.00015}
 

--- a/config/millihex_control.yaml
+++ b/config/millihex_control.yaml
@@ -9,83 +9,83 @@ millihex:
     leg1_joint1_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg1_joint1
-        pid: {p: 0.06, i: 0.0, d: 0.00015}
+        pid: {p: 0.1, i: 0.0, d: 0.0}
     leg1_joint2_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg1_joint2
-        pid: {p: 0.06, i: 0.0, d: 0.00015}
+        pid: {p: 0.1, i: 0.0, d: 0.0}
     leg1_joint3_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg1_joint3
-        pid: {p: 0.06, i: 0.0, d: 0.00015}
+        pid: {p: 0.1, i: 0.0, d: 0.0}
 
     # Leg 2
     leg2_joint1_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg2_joint1
-        pid: {p: 0.06, i: 0.0, d: 0.00015}
+        pid: {p: 0.1, i: 0.0, d: 0.0}
     leg2_joint2_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg2_joint2
-        pid: {p: 0.06, i: 0.0, d: 0.00015}
+        pid: {p: 0.1, i: 0.0, d: 0.0}
     leg2_joint3_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg2_joint3
-        pid: {p: 0.06, i: 0.0, d: 0.00015}
+        pid: {p: 0.1, i: 0.0, d: 0.0}
 
     # Leg 3
     leg3_joint1_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg3_joint1
-        pid: {p: 0.06, i: 0.0, d: 0.00015}
+        pid: {p: 0.1, i: 0.0, d: 0.0}
     leg3_joint2_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg3_joint2
-        pid: {p: 0.06, i: 0.0, d: 0.00015}
+        pid: {p: 0.1, i: 0.0, d: 0.0}
     leg3_joint3_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg3_joint3
-        pid: {p: 0.06, i: 0.0, d: 0.00015}
+        pid: {p: 0.1, i: 0.0, d: 0.0}
 
     # Leg 4
     leg4_joint1_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg4_joint1
-        pid: {p: 0.06, i: 0.0, d: 0.00015}
+        pid: {p: 0.1, i: 0.0, d: 0.0}
     leg4_joint2_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg4_joint2
-        pid: {p: 0.06, i: 0.0, d: 0.00015}
+        pid: {p: 0.1, i: 0.0, d: 0.0}
     leg4_joint3_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg4_joint3
-        pid: {p: 0.06, i: 0.0, d: 0.00015}
+        pid: {p: 0.1, i: 0.0, d: 0.0}
 
     # Leg 5
     leg5_joint1_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg5_joint1
-        pid: {p: 0.06, i: 0.0, d: 0.00015}
+        pid: {p: 0.1, i: 0.0, d: 0.0}
     leg5_joint2_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg5_joint2
-        pid: {p: 0.06, i: 0.0, d: 0.00015}
+        pid: {p: 0.1, i: 0.0, d: 0.0}
     leg5_joint3_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg5_joint3
-        pid: {p: 0.06, i: 0.0, d: 0.00015}
+        pid: {p: 0.1, i: 0.0, d: 0.0}
 
     # Leg 6
     leg6_joint1_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg6_joint1
-        pid: {p: 0.06, i: 0.0, d: 0.00015}
+        pid: {p: 0.1, i: 0.0, d: 0.0}
     leg6_joint2_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg6_joint2
-        pid: {p: 0.06, i: 0.0, d: 0.00015}
+        pid: {p: 0.1, i: 0.0, d: 0.0}
     leg6_joint3_position_controller:
         type: effort_controllers/JointPositionController
         joint: leg6_joint3
-        pid: {p: 0.06, i: 0.0, d: 0.00015}
+        pid: {p: 0.1, i: 0.0, d: 0.0}
 

--- a/config/millihex_control.yaml
+++ b/config/millihex_control.yaml
@@ -1,104 +1,91 @@
 millihex:
-  # Publish all joint states -----------------------------------
-  joint_state_controller:
-    type: joint_state_controller/JointStateController
-    publish_rate: 50
+    # Publish all joint states -----------------------------------
+    joint_state_controller:
+        type: joint_state_controller/JointStateController
+        publish_rate: 50
 
-  # Position Controllers ---------------------------------------
-  # Leg 1
-  leg1_joint1_position_controller:
-    type: effort_controllers/JointPositionController
-    joint: leg1_joint1
-    pid: {p: 0.05, i: 0.0, d: 0.0}
+    # Position Controllers ---------------------------------------
+    # Leg 1
+    leg1_joint1_position_controller:
+        type: effort_controllers/JointPositionController
+        joint: leg1_joint1
+        pid: {p: 0.1, i: 0.0, d: 0.0}
+    leg1_joint2_position_controller:
+        type: effort_controllers/JointPositionController
+        joint: leg1_joint2
+        pid: {p: 0.1, i: 0.0, d: 0.0}
+    leg1_joint3_position_controller:
+        type: effort_controllers/JointPositionController
+        joint: leg1_joint3
+        pid: {p: 0.1, i: 0.0, d: 0.0}
 
-  leg1_joint2_position_controller:
-    type: effort_controllers/JointPositionController
-    joint: leg1_joint2
-    pid: {p: 0.2, i: 0.0, d: 0.0}
+    # Leg 2
+    leg2_joint1_position_controller:
+        type: effort_controllers/JointPositionController
+        joint: leg2_joint1
+        pid: {p: 0.1, i: 0.0, d: 0.0}
+    leg2_joint2_position_controller:
+        type: effort_controllers/JointPositionController
+        joint: leg2_joint2
+        pid: {p: 0.1, i: 0.0, d: 0.0}
+    leg2_joint3_position_controller:
+        type: effort_controllers/JointPositionController
+        joint: leg2_joint3
+        pid: {p: 0.1, i: 0.0, d: 0.0}
 
-  leg1_joint3_position_controller:
-    type: effort_controllers/JointPositionController
-    joint: leg1_joint3
-    pid: {p: 0.2, i: 0.0, d: 0.0}
+    # Leg 3
+    leg3_joint1_position_controller:
+        type: effort_controllers/JointPositionController
+        joint: leg3_joint1
+        pid: {p: 0.1, i: 0.0, d: 0.0}
+    leg3_joint2_position_controller:
+        type: effort_controllers/JointPositionController
+        joint: leg3_joint2
+        pid: {p: 0.1, i: 0.0, d: 0.0}
+    leg3_joint3_position_controller:
+        type: effort_controllers/JointPositionController
+        joint: leg3_joint3
+        pid: {p: 0.1, i: 0.0, d: 0.0}
 
-  # Leg 2
-  leg2_joint1_position_controller:
-    type: effort_controllers/JointPositionController
-    joint: leg2_joint1
-    pid: {p: 0.2, i: 0.0, d: 0.0}
+    # Leg 4
+    leg4_joint1_position_controller:
+        type: effort_controllers/JointPositionController
+        joint: leg4_joint1
+        pid: {p: 0.1, i: 0.0, d: 0.0}
+    leg4_joint2_position_controller:
+        type: effort_controllers/JointPositionController
+        joint: leg4_joint2
+        pid: {p: 0.1, i: 0.0, d: 0.0}
+    leg4_joint3_position_controller:
+        type: effort_controllers/JointPositionController
+        joint: leg4_joint3
+        pid: {p: 0.1, i: 0.0, d: 0.0}
 
-  leg2_joint2_position_controller:
-    type: effort_controllers/JointPositionController
-    joint: leg2_joint2
-    pid: {p: 0.2, i: 0.0, d: 0.0}
+    # Leg 5
+    leg5_joint1_position_controller:
+        type: effort_controllers/JointPositionController
+        joint: leg5_joint1
+        pid: {p: 0.1, i: 0.0, d: 0.0}
+    leg5_joint2_position_controller:
+        type: effort_controllers/JointPositionController
+        joint: leg5_joint2
+        pid: {p: 0.1, i: 0.0, d: 0.0}
+    leg5_joint3_position_controller:
+        type: effort_controllers/JointPositionController
+        joint: leg5_joint3
+        pid: {p: 0.1, i: 0.0, d: 0.0}
 
-  leg2_joint3_position_controller:
-    type: effort_controllers/JointPositionController
-    joint: leg2_joint3
-    pid: {p: 0.2, i: 0.0, d: 0.0}
+    # Leg 6
+    leg6_joint1_position_controller:
+        type: effort_controllers/JointPositionController
+        joint: leg6_joint1
+        pid: {p: 0.1, i: 0.0, d: 0.0}
+    leg6_joint2_position_controller:
+        type: effort_controllers/JointPositionController
+        joint: leg6_joint2
+        pid: {p: 0.1, i: 0.0, d: 0.0}
+    leg6_joint3_position_controller:
+        type: effort_controllers/JointPositionController
+        joint: leg6_joint3
+        pid: {p: 0.1, i: 0.0, d: 0.0}
 
-  # Leg 3
-  leg3_joint1_position_controller:
-    type: effort_controllers/JointPositionController
-    joint: leg3_joint1
-    pid: {p: 0.2, i: 0.0, d: 0.0}
-
-  leg3_joint2_position_controller:
-    type: effort_controllers/JointPositionController
-    joint: leg3_joint2
-    pid: {p: 0.2, i: 0.0, d: 0.0}
-
-  leg3_joint3_position_controller:
-    type: effort_controllers/JointPositionController
-    joint: leg3_joint3
-    pid: {p: 0.2, i: 0.0, d: 0.0}
-
-  # Leg 4
-  leg4_joint1_position_controller:
-    type: effort_controllers/JointPositionController
-    joint: leg4_joint1
-    pid: {p: 0.2, i: 0.0, d: 0.0}
-
-  leg4_joint2_position_controller:
-    type: effort_controllers/JointPositionController
-    joint: leg4_joint2
-    pid: {p: 0.2, i: 0.0, d: 0.0}
-
-  leg4_joint3_position_controller:
-    type: effort_controllers/JointPositionController
-    joint: leg4_joint3
-    pid: {p: 0.2, i: 0.0, d: 0.0}
-
-  # Leg 5
-  leg5_joint1_position_controller:
-    type: effort_controllers/JointPositionController
-    joint: leg5_joint1
-    pid: {p: 0.2, i: 0.0, d: 0.0}
-
-  leg5_joint2_position_controller:
-    type: effort_controllers/JointPositionController
-    joint: leg5_joint2
-    pid: {p: 0.2, i: 0.0, d: 0.0}
-
-  leg5_joint3_position_controller:
-    type: effort_controllers/JointPositionController
-    joint: leg5_joint3
-    pid: {p: 0.2, i: 0.0, d: 0.0}
-
-  # Leg 6
-  leg6_joint1_position_controller:
-    type: effort_controllers/JointPositionController
-    joint: leg6_joint1
-    pid: {p: 0.2, i: 0.0, d: 0.0}
-
-  leg6_joint2_position_controller:
-    type: effort_controllers/JointPositionController
-    joint: leg6_joint2
-    pid: {p: 0.2, i: 0.0, d: 0.0}
-
-  leg6_joint3_position_controller:
-    type: effort_controllers/JointPositionController
-    joint: leg6_joint3
-    pid: {p: 0.2, i: 0.0, d: 0.0}
-
-  # To add more just add them here as the first one

--- a/config/millihex_control_autogen.py
+++ b/config/millihex_control_autogen.py
@@ -6,7 +6,7 @@ def main():
     Enables easy changes to be made to PID values."""
     
     # Change PID values for joint controller here
-    p = 0.1
+    p = 0.2
     i = 0.0
     d = 0.0
 

--- a/config/millihex_control_autogen.py
+++ b/config/millihex_control_autogen.py
@@ -1,7 +1,43 @@
 #!/usr/bin/env python3
+import sys
 
 def main():
+    """Autogenerates a joint controller yaml file for millihex robot.
+    Enables easy changes to be made to PID values."""
     
+    # Change PID values for joint controller here
+    p = 0.1
+    i = 0.0
+    d = 0.0
+
+    # Millihex leg and joint count
+    num_legs = 6
+    joints_per_leg = 3
+
+    # Write a yaml joint controller file
+    with open("millihex_control.yaml", "w") as f:
+        # Write joint_state_controller publisher
+        f.write("millihex:\n"\
+                "    # Publish all joint states -----------------------------------\n"\
+                "    joint_state_controller:\n"\
+                "        type: joint_state_controller/JointStateController\n"\
+                "        publish_rate: 50\n\n"\
+                "    # Position Controllers ---------------------------------------\n")
+
+        # Write joint_position_controller publishers
+        for k in range(num_legs):
+            k = k + 1
+            f.write(f"    # Leg {k}\n")
+
+            for j in range(joints_per_leg):
+                j = j + 1
+                f.write(f"    leg{k}_joint{j}_position_controller:\n"\
+                        f"        type: effort_controllers/JointPositionController\n"\
+                        f"        joint: leg{k}_joint{j}\n"\
+                        f"        pid: {{p: {p}, i: {i}, d: {d}}}\n")
+
+            f.write("\n")
+
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/config/millihex_control_autogen.py
+++ b/config/millihex_control_autogen.py
@@ -6,9 +6,9 @@ def main():
     Enables easy changes to be made to PID values."""
     
     # Change PID values for joint controller here
-    p = 0.1
+    p = 0.06
     i = 0.0
-    d = 0.0
+    d = 0.00015
 
     # Millihex leg and joint count
     num_legs = 6

--- a/config/millihex_control_autogen.py
+++ b/config/millihex_control_autogen.py
@@ -6,9 +6,9 @@ def main():
     Enables easy changes to be made to PID values."""
     
     # Change PID values for joint controller here
-    p = 0.2
+    p = 0.1
     i = 0.0
-    d = 0.0
+    d = 0.0000803
 
     # Millihex leg and joint count
     num_legs = 6
@@ -21,7 +21,7 @@ def main():
                 "    # Publish all joint states -----------------------------------\n"\
                 "    joint_state_controller:\n"\
                 "        type: joint_state_controller/JointStateController\n"\
-                "        publish_rate: 50\n\n"\
+                "        publish_rate: 100\n\n"\
                 "    # Joint position controllers ---------------------------------------\n")
 
         # Write joint_position_controller publishers

--- a/config/millihex_control_autogen.py
+++ b/config/millihex_control_autogen.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+
+def main():
+    
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/config/millihex_control_autogen.py
+++ b/config/millihex_control_autogen.py
@@ -22,7 +22,7 @@ def main():
                 "    joint_state_controller:\n"\
                 "        type: joint_state_controller/JointStateController\n"\
                 "        publish_rate: 50\n\n"\
-                "    # Position Controllers ---------------------------------------\n")
+                "    # Joint position controllers ---------------------------------------\n")
 
         # Write joint_position_controller publishers
         for k in range(num_legs):

--- a/config/millihex_control_autogen.py
+++ b/config/millihex_control_autogen.py
@@ -6,9 +6,9 @@ def main():
     Enables easy changes to be made to PID values."""
     
     # Change PID values for joint controller here
-    p = 0.06
+    p = 0.1
     i = 0.0
-    d = 0.00015
+    d = 0.0
 
     # Millihex leg and joint count
     num_legs = 6

--- a/robot/millihex_description.xacro
+++ b/robot/millihex_description.xacro
@@ -2,27 +2,30 @@
 <robot name="millihex" xmlns:xacro="http://www.ros.org/wiki/xacro">
 
     <!-- Physical Properties -->
-    <!-- Torso mass and x,y dimensions -->
+    <!-- PCB density ~ FR4 density (kg/m^3) -->
+    <xacro:property name="pcb_density" value="1850" />
+
+    <!-- Torso mass (kg) and x,y dimensions (m) -->
     <xacro:property name="torso_mass" value="0.01" />
     <xacro:property name="torso_x" value="0.14" />
     <xacro:property name="torso_y" value="0.04" />
 
-    <!-- Leg mass and x,y dimensions -->
+    <!-- Leg mass (kg) and x,y dimensions (m) -->
     <xacro:property name="leg_link_mass" value="0.0008" />
     <xacro:property name="leg_link_x" value="0.02" />
     <xacro:property name="leg_link_y" value="0.03" />
 
-    <!-- Joint limits -->
+    <!-- Joint limits (rad) -->
     <xacro:property name="joint_upper_limit" value="1.5708" />
     <xacro:property name="joint_lower_limit" value="-1.5708" />
     <xacro:property name="joint_effort_limit" value="0.01" />
     <xacro:property name="joint_velocity_limit" value="0.01" />
 
-    <!-- Joint damping (b) and friction (k) -->
+    <!-- Joint damping (b = N*s/m) and spring constant (k = N/m) -->
     <xacro:property name="joint_damping" value="0.00003" />
     <xacro:property name="joint_friction" value="0.001" />
 
-    <!-- PCB thickness -->
+    <!-- PCB thickness (m) -->
     <xacro:property name="pcb_thickness_z" value="0.0005" />
 
     <!-- Link Gazebo properties -->

--- a/robot/millihex_description.xacro
+++ b/robot/millihex_description.xacro
@@ -44,8 +44,6 @@
     <!-- Tarsus (Leg Link 3) Properties -->
     <xacro:property name="leg_link_3_x" value="0.01" />     <!-- x length (m) -->
     <xacro:property name="leg_link_3_y" value="0.05" />     <!-- y length (m) -->
-    <xacro:property name="foot_mu1" value="100.0" />          <!-- friction coefficient 1 -->
-    <xacro:property name="foot_mu2" value="100.0" />          <!-- friction coefficient 2 -->
     <xacro:property name="leg_link_3_mass"
         value="${pcb_density * (leg_link_3_x * leg_link_3_y * pcb_thickness_z)}" />  <!-- (kg) -->
         
@@ -55,11 +53,17 @@
     <xacro:property name="joint_link_mass"
         value="${pcb_density * (pi * (joint_link_r * joint_link_r) * joint_link_l)}" />  <!-- (kg) -->
 
-    <!-- Revolute Joint Properties -->
+    <!-- Link Friction and -->
+    <xacro:property name="link_kp" value="1000000.0" />  <!-- Contact stiffness -->
+    <xacro:property name="link_kd" value="1.0" />        <!-- Contact damping -->
+    <xacro:property name="link_mu1" value="100.0" />     <!-- Friction coefficient 1 -->
+    <xacro:property name="link_mu2" value="100.0" />     <!-- Friction coefficient 2 -->
+
+    <!-- Revolute Joint Limits -->
     <xacro:property name="joint_upper_limit" value="${pi / 2}" />   <!-- (rad) -->
     <xacro:property name="joint_lower_limit" value="${-pi / 2}" />  <!-- (rad) -->
-    <xacro:property name="joint_effort_limit" value="1.0" />        <!-- (N*m) -->
-    <xacro:property name="joint_velocity_limit" value="0.1" />      <!-- (rad/s) -->
+    <xacro:property name="joint_effort_limit" value="0.01" />        <!-- (N*m) -->
+    <xacro:property name="joint_velocity_limit" value="0.01" />      <!-- (rad/s) -->
     
     <!-- Thorax Leg Joint Attachment Positions -->
     <xacro:property name="leg_spacing" value="${(2 * coxa_x) + leg_link_2_x}" />
@@ -124,6 +128,10 @@
 
         <!-- Gazebo properties -->
         <gazebo reference="thorax">
+            <kp>${link_kp}</kp>
+            <kd>${link_kd}</kd>
+            <mu1>${link_mu1}</mu1>
+            <mu2>${link_mu2}</mu2>
             <material>Gazebo/${color}</material>
         </gazebo>
 
@@ -161,6 +169,10 @@
 
         <!-- Gazebo properties -->
         <gazebo reference="leg${leg_number}_coxa">
+            <kp>${link_kp}</kp>
+            <kd>${link_kd}</kd>
+            <mu1>${link_mu1}</mu1>
+            <mu2>${link_mu2}</mu2>
             <material>Gazebo/${color}</material>
         </gazebo>
     </xacro:macro>
@@ -192,6 +204,10 @@
 
         <!-- Gazebo properties -->
         <gazebo reference="leg${leg_number}_link1">
+            <kp>${link_kp}</kp>
+            <kd>${link_kd}</kd>
+            <mu1>${link_mu1}</mu1>
+            <mu2>${link_mu2}</mu2>
             <material>Gazebo/${color}</material>
         </gazebo>
     </xacro:macro>
@@ -223,6 +239,10 @@
 
         <!-- Gazebo properties -->
         <gazebo reference="leg${leg_number}_link2">
+            <kp>${link_kp}</kp>
+            <kd>${link_kd}</kd>
+            <mu1>${link_mu1}</mu1>
+            <mu2>${link_mu2}</mu2>
             <material>Gazebo/${color}</material>
         </gazebo>
     </xacro:macro>
@@ -254,8 +274,10 @@
 
         <!-- Gazebo properties -->
         <gazebo reference="leg${leg_number}_link3">
-            <mu1>${foot_mu1}</mu1>
-            <mu2>${foot_mu2}</mu2>
+            <kp>${link_kp}</kp>
+            <kd>${link_kd}</kd>
+            <mu1>${link_mu1}</mu1>
+            <mu2>${link_mu2}</mu2>
             <material>Gazebo/${color}</material>
         </gazebo>
     </xacro:macro>
@@ -288,6 +310,10 @@
 
         <!-- Gazebo properties -->
         <gazebo reference="leg${leg_number}_joint_link${link_number}">
+            <kp>${link_kp}</kp>
+            <kd>${link_kd}</kd>
+            <mu1>${link_mu1}</mu1>
+            <mu2>${link_mu2}</mu2>
             <material>Gazebo/${color}</material>
         </gazebo>
     </xacro:macro>

--- a/robot/millihex_description.xacro
+++ b/robot/millihex_description.xacro
@@ -20,53 +20,45 @@
     <!-- Thorax Properties -->
     <xacro:property name="thorax_x" value="0.25" />     <!-- x length (m) -->
     <xacro:property name="thorax_y" value="0.02" />     <!-- y length (m) -->
-    <xacro:property name="thorax_kp" value="1000.0" />  <!-- contact stiffness -->
-    <xacro:property name="thorax_kd" value="1000.0" />  <!-- contact damping -->
-    <xacro:property name="thorax_mu1" value="10.0" />   <!-- friction coef 1 -->
-    <xacro:property name="thorax_mu2" value="10.0" />   <!-- friction coef 2 -->
     <xacro:property name="thorax_mass"
         value="${pcb_density * (thorax_x * thorax_y * pcb_thickness_z)}" />  <!-- (kg) -->
     
     <!-- Coxa Properties -->
     <xacro:property name="coxa_x" value="0.01" />     <!-- x length (m) -->
     <xacro:property name="coxa_y" value="0.01" />     <!-- y length (m) -->
-    <xacro:property name="coxa_kp" value="1000.0" />  <!-- contact stiffness -->
-    <xacro:property name="coxa_kd" value="1000.0" />  <!-- contact damping -->
-    <xacro:property name="coxa_mu1" value="10.0" />   <!-- friction coef 1 -->
-    <xacro:property name="coxa_mu2" value="10.0" />   <!-- friction coef 2 -->
     <xacro:property name="coxa_mass"
         value="${pcb_density * (coxa_x * coxa_y * pcb_thickness_z)}" />  <!-- (kg) -->
 
     <!-- Femur (Leg Link 1) Properties -->
     <xacro:property name="leg_link_1_x" value="0.01" />     <!-- x length (m) -->
     <xacro:property name="leg_link_1_y" value="0.05" />     <!-- y length (m) -->
-    <xacro:property name="leg_link_1_kp" value="1000.0" />  <!-- contact stiffness -->
-    <xacro:property name="leg_link_1_kd" value="1000.0" />  <!-- contact damping -->
-    <xacro:property name="leg_link_1_mu1" value="10.0" />   <!-- friction coef 1 -->
-    <xacro:property name="leg_link_1_mu2" value="10.0" />   <!-- friction coef 2 -->
     <xacro:property name="leg_link_1_mass"
         value="${pcb_density * (leg_link_1_x * leg_link_2_y * pcb_thickness_z)}" />  <!-- (kg) -->
 
     <!-- Tibia (Leg Link 2) Properties -->
     <xacro:property name="leg_link_2_x" value="0.05" />     <!-- x length (m) -->
     <xacro:property name="leg_link_2_y" value="0.01" />     <!-- y length (m) -->
-    <xacro:property name="leg_link_2_kp" value="1000.0" />  <!-- contact stiffness -->
-    <xacro:property name="leg_link_2_kd" value="1000.0" />  <!-- contact damping -->
-    <xacro:property name="leg_link_2_mu1" value="10.0" />   <!-- friction coef 1 -->
-    <xacro:property name="leg_link_2_mu2" value="10.0" />   <!-- friction coef 2 -->
     <xacro:property name="leg_link_2_mass"
         value="${pcb_density * (leg_link_2_x * leg_link_2_y * pcb_thickness_z)}" />  <!-- (kg) -->
 
     <!-- Tarsus (Leg Link 3) Properties -->
     <xacro:property name="leg_link_3_x" value="0.01" />     <!-- x length (m) -->
     <xacro:property name="leg_link_3_y" value="0.05" />     <!-- y length (m) -->
-    <xacro:property name="leg_link_3_kp" value="1000.0" />  <!-- contact stiffness -->
-    <xacro:property name="leg_link_3_kd" value="1000.0" />  <!-- contact damping -->
-    <xacro:property name="leg_link_3_mu1" value="10.0" />   <!-- friction coef 1 -->
-    <xacro:property name="leg_link_3_mu2" value="10.0" />   <!-- friction coef 2 -->
     <xacro:property name="leg_link_3_mass"
         value="${pcb_density * (leg_link_3_x * leg_link_3_y * pcb_thickness_z)}" />  <!-- (kg) -->
+        
+    <!-- Joint Link Properties -->
+    <xacro:property name="joint_link_r" value="0.0015" />  <!-- radius (m) -->
+    <xacro:property name="joint_link_l" value="0.01" />    <!-- length (m) -->
+    <xacro:property name="joint_link_mass"
+        value="${pcb_density * (pi * (joint_link_r * joint_link_r) * joint_link_l)}" />  <!-- (kg) -->
 
+    <!-- Revolute Joint Properties -->
+    <xacro:property name="joint_upper_limit" value="${pi / 2}" />   <!-- (rad) -->
+    <xacro:property name="joint_lower_limit" value="${-pi / 2}" />  <!-- (rad) -->
+    <xacro:property name="joint_effort_limit" value="0.1" />        <!-- (N*m) -->
+    <xacro:property name="joint_velocity_limit" value="${pi / 4}" />      <!-- (rad/s) -->
+    
     <!-- Thorax Leg Joint Attachment Positions -->
     <xacro:property name="leg_spacing" value="${(2 * coxa_x) + leg_link_2_x}" />
     <xacro:property name="frontal_leg_x" value="${(thorax_x / 2) - (coxa_x / 2)}" />
@@ -74,18 +66,6 @@
     <xacro:property name="hind_leg_x" value="${medial_leg_x - leg_spacing}" />
     <xacro:property name="right_side_y" value="${(thorax_y / 2) + (coxa_y / 2)}" />
     <xacro:property name="left_side_y" value="${-((thorax_y / 2) + (coxa_y / 2))}" />
-        
-    <!-- Joint Link Properties -->
-    <xacro:property name="joint_link_r" value="0.0015" />  <!-- radius (m) -->
-    <xacro:property name="joint_link_l" value="0.01" />    <!-- length (m) -->
-
-    <!-- Revolute Joint Properties -->
-    <xacro:property name="joint_upper_limit" value="${pi / 2}" />   <!-- (rad) -->
-    <xacro:property name="joint_lower_limit" value="${-pi / 2}" />  <!-- (rad) -->
-    <xacro:property name="joint_effort_limit" value="0.1" />        <!-- (rad/s) -->
-    <xacro:property name="joint_velocity_limit" value="0.1" />      <!-- (rad/s) -->
-    <xacro:property name="joint_damping" value="0.0" />   <!-- damping (N*m*s/rad)-->
-    <xacro:property name="joint_friction" value="0.0" />  <!-- friction (N*m) -->
 
     <!-- Color Definitions -->
     <material name="Black">
@@ -100,8 +80,16 @@
 
     <!-- Calculate Moment of Inertia of a Box -->
     <xacro:macro name="box_inertia" params="mass x y z">
-        <inertia ixx="${mass*(y*y+z*z)/12}" ixy = "0" ixz = "0"
-            iyy="${mass*(x*x+z*z)/12}" iyz = "0" izz="${mass*(x*x+y*y)/12}" />
+        <inertia ixx="${(1 / 12) * mass * ((y * y) + (z * z))}" ixy = "0" ixz = "0"
+                 iyy="${(1 / 12) * mass * ((x * x) + (z * z))}" iyz = "0"
+                 izz="${(1 / 12) * mass * ((x * x) + (y * y))}" />
+    </xacro:macro>
+
+    <!-- Calculate Moment of Inertia of a Cylinder -->
+    <xacro:macro name="cylinder_inerta" params="mass r l">
+        <inertia ixx="${(1 / 12) * mass * (l * l)}" ixy = "0" ixz = "0"
+                 iyy="${(1 / 12) * mass * (l * l)}" iyz = "0"
+                 izz="${(1 / 2) * mass * (r * r)}" />
     </xacro:macro>
 
     <!-- Thorax Definition -->
@@ -112,7 +100,7 @@
         <!-- Thorax Geometry -->
         <link name="thorax">
             <inertial>
-                <origin xyz="0 0 ${pcb_thickness_z / 2}" rpy="0 0 0" />
+                <origin xyz="0 0 0" rpy="0 0 0" />
                 <mass value="${thorax_mass}" />
                 <xacro:box_inertia mass="${thorax_mass}" x="${thorax_x}"
                     y="${thorax_y}" z="${pcb_thickness_z}" />
@@ -134,10 +122,6 @@
 
         <!-- Gazebo properties -->
         <gazebo reference="thorax">
-            <kp>${thorax_kp}</kp>
-            <kd>${thorax_kd}</kd>
-            <mu1>${thorax_mu1}</mu1>
-            <mu2>${thorax_mu2}</mu2>
             <material>Gazebo/${color}</material>
         </gazebo>
 
@@ -153,7 +137,7 @@
         <!-- Coxa Geometry -->
         <link name="leg${leg_number}_coxa">
             <inertial>
-                <origin xyz="0 0 ${pcb_thickness_z / 2}" rpy="0 0 0" />
+                <origin xyz="0 0 0" rpy="0 0 0" />
                 <mass value="${coxa_mass}" />
                 <xacro:box_inertia mass="${coxa_mass}" x="${coxa_x}"
                     y="${coxa_y}" z="${pcb_thickness_z}" />
@@ -175,10 +159,6 @@
 
         <!-- Gazebo properties -->
         <gazebo reference="leg${leg_number}_coxa">
-            <kp>${coxa_kp}</kp>
-            <kd>${coxa_kd}</kd>
-            <mu1>${coxa_mu1}</mu1>
-            <mu2>${coxa_mu2}</mu2>
             <material>Gazebo/${color}</material>
         </gazebo>
     </xacro:macro>
@@ -188,7 +168,7 @@
         <!-- Femur (Leg Link 1) Geometry -->
         <link name="leg${leg_number}_link1">
             <inertial>
-                <origin xyz="0 0 ${pcb_thickness_z / 2}" rpy="0 0 0" />
+                <origin xyz="0 0 0" rpy="0 0 0" />
                 <mass value="${leg_link_1_mass}" />
                 <xacro:box_inertia mass="${leg_link_1_mass}" x="${leg_link_1_x}"
                     y="${leg_link_1_y}" z="${pcb_thickness_z}" />
@@ -210,10 +190,6 @@
 
         <!-- Gazebo properties -->
         <gazebo reference="leg${leg_number}_link1">
-            <kp>${leg_link_1_kp}</kp>
-            <kd>${leg_link_1_kd}</kd>
-            <mu1>${leg_link_1_mu1}</mu1>
-            <mu2>${leg_link_1_mu2}</mu2>
             <material>Gazebo/${color}</material>
         </gazebo>
     </xacro:macro>
@@ -223,7 +199,7 @@
         <!-- Tibia (Leg Link 2) Geometry -->
         <link name="leg${leg_number}_link2">
             <inertial>
-                <origin xyz="0 0 ${pcb_thickness_z / 2}" rpy="0 0 0" />
+                <origin xyz="0 0 0" rpy="0 0 0" />
                 <mass value="${leg_link_2_mass}" />
                 <xacro:box_inertia mass="${leg_link_2_mass}" x="${leg_link_2_x}"
                     y="${leg_link_2_y}" z="${pcb_thickness_z}" />
@@ -245,10 +221,6 @@
 
         <!-- Gazebo properties -->
         <gazebo reference="leg${leg_number}_link2">
-            <kp>${leg_link_2_kp}</kp>
-            <kd>${leg_link_2_kd}</kd>
-            <mu1>${leg_link_2_mu1}</mu1>
-            <mu2>${leg_link_2_mu2}</mu2>
             <material>Gazebo/${color}</material>
         </gazebo>
     </xacro:macro>
@@ -258,7 +230,7 @@
         <!-- Tarsus (Leg Link 3) Geometry -->
         <link name="leg${leg_number}_link3">
             <inertial>
-                <origin xyz="0 0 ${pcb_thickness_z / 2}" rpy="0 0 0" />
+                <origin xyz="0 0 0" rpy="0 0 0" />
                 <mass value="${leg_link_3_mass}" />
                 <xacro:box_inertia mass="${leg_link_3_mass}" x="${leg_link_3_x}"
                     y="${leg_link_3_y}" z="${pcb_thickness_z}" />
@@ -280,10 +252,6 @@
 
         <!-- Gazebo properties -->
         <gazebo reference="leg${leg_number}_link3">
-            <kp>${leg_link_3_kp}</kp>
-            <kd>${leg_link_3_kd}</kd>
-            <mu1>${leg_link_3_mu1}</mu1>
-            <mu2>${leg_link_3_mu2}</mu2>
             <material>Gazebo/${color}</material>
         </gazebo>
     </xacro:macro>
@@ -293,6 +261,12 @@
         params="leg_number link_number yaw color">
         <!-- Joint Link Geometry -->
         <link name="leg${leg_number}_joint_link${link_number}">
+            <inertial>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <mass value="${joint_link_mass}" />
+                <xacro:cylinder_inerta mass="${joint_link_mass}"
+                    r="${joint_link_r}" l="${joint_link_l}" />
+            </inertial>
             <collision>
                 <origin xyz="0 0 0" rpy="0 0 0" />
                 <geometry>
@@ -345,7 +319,6 @@
             <parent link="leg${leg_number}_coxa" />
             <child link="leg${leg_number}_joint_link1" />
             <origin xyz="0 ${(coxa_y / 2) + (joint_link_r)} 0" rpy="0 0 0" />
-            <dynamics damping="${joint_damping}" friction="${joint_friction}" />
             <limit lower="${joint_lower_limit}"
                    upper="${joint_upper_limit}"
                    effort="${joint_effort_limit}"
@@ -372,7 +345,6 @@
             <child link="leg${leg_number}_joint_link2" />
             <origin xyz="${-((leg_link_1_x / 2) + (joint_link_r))}
                 ${(leg_link_1_y / 2) - (joint_link_l / 2)} 0" rpy="0 0 0" />
-            <dynamics damping="${joint_damping}" friction="${joint_friction}" />
             <limit lower="${joint_lower_limit}"
                    upper="${joint_upper_limit}"
                    effort="${joint_effort_limit}"
@@ -399,7 +371,6 @@
             <child link="leg${leg_number}_joint_link3" />
             <origin xyz="${-(leg_link_2_x / 2) + (joint_link_l / 2)}
                 ${(leg_link_2_y / 2) + (joint_link_r)} 0" rpy="0 0 0" />
-            <dynamics damping="${joint_damping}" friction="${joint_friction}" />
             <limit lower="${joint_lower_limit}"
                    upper="${joint_upper_limit}"
                    effort="${joint_effort_limit}"

--- a/robot/millihex_description.xacro
+++ b/robot/millihex_description.xacro
@@ -95,7 +95,7 @@
     <xacro:macro name="cylinder_inerta" params="mass r l">
         <inertia ixx="${(1 / 12) * mass * (3 * (r * r) + (l * l))}" ixy = "0" ixz = "0"
                  iyy="${(1 / 12) * mass * (3 * (r * r) + (l * l))}" iyz = "0"
-                 izz="${(1 / 12) * mass * (r * r)}" />
+                 izz="${(1 / 2) * mass * (r * r)}" />
     </xacro:macro>
 
     <!-- Thorax Definition -->

--- a/robot/millihex_description.xacro
+++ b/robot/millihex_description.xacro
@@ -21,9 +21,9 @@
     <xacro:property name="leg_link_mass"
         value="${pcb_density * leg_link_x * leg_link_y * pcb_thickness_z}" />
 
-    <!-- Massless Joint Link x,y dimensions (m) -->
-    <xacro:property name="joint_link_r" value="${pcb_thickness_z / 2}" />
-    <xacro:property name="joint_link_l" value="${leg_link_x}"
+    <!-- Fake Joint Link r,l dimensions (m) -->
+    <xacro:property name="fake_joint_link_r" value="${pcb_thickness_z / 2}" />
+    <xacro:property name="fake_joint_link_l" value="${leg_link_x}" />
 
     <!-- Joint limits (rad) -->
     <xacro:property name="joint_upper_limit" value="1.5708" />
@@ -64,12 +64,12 @@
     </xacro:macro>
 
 
-    <!-- Base and Torso Definition -->
+    <!-- Torso Definition -->
     <xacro:macro name="millihex_torso" params="color">
-        <!-- Dummy link to support KDL -->
+        <!-- Dummy Base Link to support KDL -->
         <link name="base_link" />
 
-        <!-- Torso geometry without legs -->
+        <!-- Torso Geometry -->
         <link name="torso">
             <inertial>
                 <origin xyz="0 0 ${pcb_thickness_z / 2}" rpy="0 0 0" />
@@ -109,10 +109,43 @@
     </xacro:macro>
 
 
+    <!-- Fake Joint Link Definition -->
+    <xacro:macro name="millihex_fake_joint_link"
+        params="leg_number link_number x_length y_length color">
+
+        <!-- Fake Joint Link Geometry -->
+        <link name="leg${leg_number}_link${link_number}">
+            <collision>
+                <origin xyz="-${x_length / 2} -${y_length / 2} 0" rpy="0 0 0" />
+                <geometry>
+                    <cylinder radius="${fake_joint_link_r}"
+                        length="${fake_joint_link_l}" />
+                </geometry>
+            </collision>
+            <visual>
+                <origin xyz="-${x_length / 2} -${y_length / 2} 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="${x_length} ${y_length} ${pcb_thickness_z}" />
+                </geometry>
+                <material name="${color}"/>
+            </visual>
+        </link>
+
+        <!-- Gazebo properties -->
+        <gazebo reference="leg${leg_number}_link${link_number}">
+            <kp>${link_kp}</kp>
+            <kd>${link_kd}</kd>
+            <mu1>${link_mu1}</mu1>
+            <mu2>${link_mu2}</mu2>
+            <material>Gazebo/${color}</material>
+        </gazebo>
+    </xacro:macro>
+
+
     <!-- Leg Link Definition -->
     <xacro:macro name="millihex_leg_link"
         params="leg_number link_number x_length y_length color">
-        <!-- Leg geometry -->
+        <!-- Leg Link Geometry -->
         <link name="leg${leg_number}_link${link_number}">
             <inertial>
                 <origin xyz="0 0 ${pcb_thickness_z / 2}" rpy="0 0 0" />

--- a/robot/millihex_description.xacro
+++ b/robot/millihex_description.xacro
@@ -55,15 +55,15 @@
 
     <!-- Link Friction and -->
     <xacro:property name="link_kp" value="1000000.0" />  <!-- Contact stiffness -->
-    <xacro:property name="link_kd" value="1.0" />        <!-- Contact damping -->
+    <xacro:property name="link_kd" value="100.0" />        <!-- Contact damping -->
     <xacro:property name="link_mu1" value="100.0" />     <!-- Friction coefficient 1 -->
     <xacro:property name="link_mu2" value="100.0" />     <!-- Friction coefficient 2 -->
 
     <!-- Revolute Joint Limits -->
     <xacro:property name="joint_upper_limit" value="${pi / 2}" />   <!-- (rad) -->
     <xacro:property name="joint_lower_limit" value="${-pi / 2}" />  <!-- (rad) -->
-    <xacro:property name="joint_effort_limit" value="0.01" />        <!-- (N*m) -->
-    <xacro:property name="joint_velocity_limit" value="0.01" />      <!-- (rad/s) -->
+    <xacro:property name="joint_effort_limit" value="1.0" />        <!-- (N*m) -->
+    <xacro:property name="joint_velocity_limit" value="1.0" />      <!-- (rad/s) -->
     
     <!-- Thorax Leg Joint Attachment Positions -->
     <xacro:property name="leg_spacing" value="${(2 * coxa_x) + leg_link2_x}" />

--- a/robot/millihex_description.xacro
+++ b/robot/millihex_description.xacro
@@ -1,5 +1,21 @@
+<!-- Check URDF: -->
+<!-- rosrun xacro xacro millihex_description.xacro > millihex_description.urdf -->
+
 <?xml version="1.0"?>
 <robot name="millihex" xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+    <!-- Equations -->
+    <!-- Calculate Mass of a Box -->
+    <xacro:macro name="box_mass" params="density x y z">
+        <mass value="${density*x*y*z}" />
+    </xacro:macro>
+
+    <!-- Calculate Moment of Inertia of a Box -->
+    <xacro:macro name="box_inertia" params="mass x y z">
+        <inertia ixx="${mass*(y*y+z*z)/12}" ixy = "0" ixz = "0"
+            iyy="${mass*(x*x+z*z)/12}" iyz = "0" izz="${mass*(x*x+y*y)/12}" />
+    </xacro:macro>
+
 
     <!-- Physical Properties -->
     <!-- PCB density ~ FR4 density (kg/m^3) -->
@@ -44,17 +60,9 @@
     <material name="Black">
         <color rgba="0 0 0 1" />
     </material>
-
     <material name="Orange">
         <color rgba="0.98 0.41 0.055 1" />
     </material>
-
-
-    <!-- Calculate Moment of Inertia of a Box -->
-    <xacro:macro name="box_inertia" params="mass x y z">
-        <inertia ixx="${mass*(y*y+z*z)/12}" ixy = "0" ixz = "0"
-            iyy="${mass*(x*x+z*z)/12}" iyz = "0" izz="${mass*(x*x+y*y)/12}" />
-    </xacro:macro>
 
 
     <!-- Base and Torso Definition -->
@@ -295,9 +303,8 @@
     </xacro:macro>
   
 
-    <!-- Build Robot by Filling in Macro Parameters -->
+    <!-- Build Robot and Gazebo Control Library -->
     <xacro:millihex_body />
-
     <xacro:millihex_control namespace="millihex" />
 
 </robot>

--- a/robot/millihex_description.xacro
+++ b/robot/millihex_description.xacro
@@ -30,22 +30,22 @@
         value="${pcb_density * (coxa_x * coxa_y * pcb_thickness_z)}" />  <!-- (kg) -->
 
     <!-- Femur (Leg Link 1) Properties -->
-    <xacro:property name="leg_link_1_x" value="0.01" />     <!-- x length (m) -->
-    <xacro:property name="leg_link_1_y" value="0.05" />     <!-- y length (m) -->
-    <xacro:property name="leg_link_1_mass"
-        value="${pcb_density * (leg_link_1_x * leg_link_2_y * pcb_thickness_z)}" />  <!-- (kg) -->
+    <xacro:property name="leg_link1_x" value="0.01" />     <!-- x length (m) -->
+    <xacro:property name="leg_link1_y" value="0.05" />     <!-- y length (m) -->
+    <xacro:property name="leg_link1_mass"
+        value="${pcb_density * (leg_link1_x * leg_link1_y * pcb_thickness_z)}" />  <!-- (kg) -->
 
     <!-- Tibia (Leg Link 2) Properties -->
-    <xacro:property name="leg_link_2_x" value="0.05" />     <!-- x length (m) -->
-    <xacro:property name="leg_link_2_y" value="0.01" />     <!-- y length (m) -->
-    <xacro:property name="leg_link_2_mass"
-        value="${pcb_density * (leg_link_2_x * leg_link_2_y * pcb_thickness_z)}" />  <!-- (kg) -->
+    <xacro:property name="leg_link2_x" value="0.05" />     <!-- x length (m) -->
+    <xacro:property name="leg_link2_y" value="0.01" />     <!-- y length (m) -->
+    <xacro:property name="leg_link2_mass"
+        value="${pcb_density * (leg_link2_x * leg_link2_y * pcb_thickness_z)}" />  <!-- (kg) -->
 
     <!-- Tarsus (Leg Link 3) Properties -->
-    <xacro:property name="leg_link_3_x" value="0.01" />     <!-- x length (m) -->
-    <xacro:property name="leg_link_3_y" value="0.05" />     <!-- y length (m) -->
-    <xacro:property name="leg_link_3_mass"
-        value="${pcb_density * (leg_link_3_x * leg_link_3_y * pcb_thickness_z)}" />  <!-- (kg) -->
+    <xacro:property name="leg_link3_x" value="0.01" />     <!-- x length (m) -->
+    <xacro:property name="leg_link3_y" value="0.05" />     <!-- y length (m) -->
+    <xacro:property name="leg_link3_mass"
+        value="${pcb_density * (leg_link3_x * leg_link3_y * pcb_thickness_z)}" />  <!-- (kg) -->
         
     <!-- Joint Link Properties -->
     <xacro:property name="joint_link_r" value="${pcb_thickness_z / 2}" />  <!-- radius (m) -->
@@ -66,12 +66,10 @@
     <xacro:property name="joint_velocity_limit" value="0.01" />      <!-- (rad/s) -->
     
     <!-- Thorax Leg Joint Attachment Positions -->
-    <xacro:property name="leg_spacing" value="${(2 * coxa_x) + leg_link_2_x}" />
+    <xacro:property name="leg_spacing" value="${(2 * coxa_x) + leg_link2_x}" />
     <xacro:property name="frontal_leg_x" value="${(thorax_x / 2) - (coxa_x / 2)}" />
     <xacro:property name="medial_leg_x" value="${frontal_leg_x - leg_spacing}" />
     <xacro:property name="hind_leg_x" value="${medial_leg_x - leg_spacing}" />
-    <xacro:property name="right_side_y" value="${(thorax_y / 2) + (coxa_y / 2)}" />
-    <xacro:property name="left_side_y" value="${-((thorax_y / 2) + (coxa_y / 2))}" />
 
     <!-- Color Definitions -->
     <material name="Black">
@@ -153,13 +151,13 @@
                     y="${coxa_y}" z="${pcb_thickness_z}" />
             </inertial>
             <collision>
-                <origin xyz="0 0 0" rpy="0 0 0" />
+                <origin xyz="0 ${coxa_y / 2} 0" rpy="0 0 0" />
                 <geometry>
                     <box size="${coxa_x} ${coxa_y} ${pcb_thickness_z}" />
                 </geometry>
             </collision>
             <visual>
-                <origin xyz="0 0 0" rpy="0 0 0" />
+                <origin xyz="0 ${coxa_y / 2} 0" rpy="0 0 0" />
                 <geometry>
                     <box size="${coxa_x} ${coxa_y} ${pcb_thickness_z}" />
                 </geometry>
@@ -178,25 +176,25 @@
     </xacro:macro>
 
     <!-- Femur (Leg Link 1) Definition -->
-    <xacro:macro name="millihex_leg_link_1" params="leg_number color">
+    <xacro:macro name="millihex_leg_link1" params="leg_number color">
         <!-- Femur (Leg Link 1) Geometry -->
         <link name="leg${leg_number}_link1">
             <inertial>
                 <origin xyz="0 0 0" rpy="0 0 0" />
-                <mass value="${leg_link_1_mass}" />
-                <xacro:box_inertia mass="${leg_link_1_mass}" x="${leg_link_1_x}"
-                    y="${leg_link_1_y}" z="${pcb_thickness_z}" />
+                <mass value="${leg_link1_mass}" />
+                <xacro:box_inertia mass="${leg_link1_mass}" x="${leg_link1_x}"
+                    y="${leg_link1_y}" z="${pcb_thickness_z}" />
             </inertial>
             <collision>
-                <origin xyz="0 0 0" rpy="0 0 0" />
+                <origin xyz="0 ${leg_link1_y / 2} 0" rpy="0 0 0" />
                 <geometry>
-                    <box size="${leg_link_1_x} ${leg_link_1_y} ${pcb_thickness_z}" />
+                    <box size="${leg_link1_x} ${leg_link1_y} ${pcb_thickness_z}" />
                 </geometry>
             </collision>
             <visual>
-                <origin xyz="0 0 0" rpy="0 0 0" />
+                <origin xyz="0 ${leg_link1_y / 2} 0" rpy="0 0 0" />
                 <geometry>
-                    <box size="${leg_link_1_x} ${leg_link_1_y} ${pcb_thickness_z}" />
+                    <box size="${leg_link1_x} ${leg_link1_y} ${pcb_thickness_z}" />
                 </geometry>
                 <material name="${color}"/>
             </visual>
@@ -213,25 +211,25 @@
     </xacro:macro>
 
     <!-- Tibia (Leg Link 2) Definition -->
-    <xacro:macro name="millihex_leg_link_2" params="leg_number color">
+    <xacro:macro name="millihex_leg_link2" params="leg_number color">
         <!-- Tibia (Leg Link 2) Geometry -->
         <link name="leg${leg_number}_link2">
             <inertial>
                 <origin xyz="0 0 0" rpy="0 0 0" />
-                <mass value="${leg_link_2_mass}" />
-                <xacro:box_inertia mass="${leg_link_2_mass}" x="${leg_link_2_x}"
-                    y="${leg_link_2_y}" z="${pcb_thickness_z}" />
+                <mass value="${leg_link2_mass}" />
+                <xacro:box_inertia mass="${leg_link2_mass}" x="${leg_link2_x}"
+                    y="${leg_link2_y}" z="${pcb_thickness_z}" />
             </inertial>
             <collision>
-                <origin xyz="0 0 0" rpy="0 0 0" />
+                <origin xyz="${-leg_link2_x / 2} 0 0" rpy="0 0 0" />
                 <geometry>
-                    <box size="${leg_link_2_x} ${leg_link_2_y} ${pcb_thickness_z}" />
+                    <box size="${leg_link2_x} ${leg_link2_y} ${pcb_thickness_z}" />
                 </geometry>
             </collision>
             <visual>
-                <origin xyz="0 0 0" rpy="0 0 0" />
+                <origin xyz="${-leg_link2_x / 2} 0 0" rpy="0 0 0" />
                 <geometry>
-                    <box size="${leg_link_2_x} ${leg_link_2_y} ${pcb_thickness_z}" />
+                    <box size="${leg_link2_x} ${leg_link2_y} ${pcb_thickness_z}" />
                 </geometry>
                 <material name="${color}"/>
             </visual>
@@ -248,25 +246,25 @@
     </xacro:macro>
 
     <!-- Tarsus (Leg Link 3) Definition -->
-    <xacro:macro name="millihex_leg_link_3" params="leg_number color">
+    <xacro:macro name="millihex_leg_link3" params="leg_number color">
         <!-- Tarsus (Leg Link 3) Geometry -->
         <link name="leg${leg_number}_link3">
             <inertial>
                 <origin xyz="0 0 0" rpy="0 0 0" />
-                <mass value="${leg_link_3_mass}" />
-                <xacro:box_inertia mass="${leg_link_3_mass}" x="${leg_link_3_x}"
-                    y="${leg_link_3_y}" z="${pcb_thickness_z}" />
+                <mass value="${leg_link3_mass}" />
+                <xacro:box_inertia mass="${leg_link3_mass}" x="${leg_link3_x}"
+                    y="${leg_link3_y}" z="${pcb_thickness_z}" />
             </inertial>
             <collision>
-                <origin xyz="0 0 0" rpy="0 0 0" />
+                <origin xyz="0 ${leg_link3_y / 2} 0" rpy="0 0 0" />
                 <geometry>
-                    <box size="${leg_link_3_x} ${leg_link_3_y} ${pcb_thickness_z}" />
+                    <box size="${leg_link3_x} ${leg_link3_y} ${pcb_thickness_z}" />
                 </geometry>
             </collision>
             <visual>
-                <origin xyz="0 0 0" rpy="0 0 0" />
+                <origin xyz="0 ${leg_link3_y / 2} 0" rpy="0 0 0" />
                 <geometry>
-                    <box size="${leg_link_3_x} ${leg_link_3_y} ${pcb_thickness_z}" />
+                    <box size="${leg_link3_x} ${leg_link3_y} ${pcb_thickness_z}" />
                 </geometry>
                 <material name="${color}"/>
             </visual>
@@ -341,14 +339,15 @@
         <!-- Coxa -->
         <xacro:millihex_coxa leg_number="${leg_number}" color="Black" />
 
-        <!-- Coxa to Femur Joint Link (Joint Link 1) -->
+        <!-- Joint Link 1 -->
         <xacro:millihex_joint_link leg_number="${leg_number}" link_number="1"
             yaw="0.0" color="White" />
-        <!-- leg#_joint1 -->
+
+        <!-- Joint 1 -->
         <joint name="leg${leg_number}_joint1" type="revolute">
             <parent link="leg${leg_number}_coxa" />
             <child link="leg${leg_number}_joint_link1" />
-            <origin xyz="0 ${(coxa_y / 2) + (joint_link_r)} 0" rpy="0 0 0" />
+            <origin xyz="0 ${coxa_y + joint_link_r} 0" rpy="0 0 0" />
             <limit lower="${joint_lower_limit}"
                    upper="${joint_upper_limit}"
                    effort="${joint_effort_limit}"
@@ -358,23 +357,25 @@
         <xacro:leg_transmission leg_number="${leg_number}" joint_number="1" />
 
         <!-- Femur (Leg Link 1) -->
-        <xacro:millihex_leg_link_1 leg_number="${leg_number}" color="Orange" />
-        <!-- leg#_fixed_joint1 -->
+        <xacro:millihex_leg_link1 leg_number="${leg_number}" color="Orange" />
+
+        <!-- Fixed Joint 1 -->
         <joint name="leg${leg_number}_fixed_joint1" type="fixed">
             <parent link="leg${leg_number}_joint_link1" />
             <child link="leg${leg_number}_link1" />
-            <origin xyz="0 ${(leg_link_1_y / 2) + (joint_link_r)} 0" rpy="0 0 0" />
+            <origin xyz="0 ${joint_link_r} 0" rpy="0 0 0" />
         </joint>
 
-        <!-- Femur to Tibia Joint Link (Joint Link 2) -->
+        <!-- Joint Link 2 -->
         <xacro:millihex_joint_link leg_number="${leg_number}" link_number="2"
             yaw="${pi / 2}" color="White" />
-        <!-- leg#_joint2 -->
+
+        <!-- Joint 2 -->
         <joint name="leg${leg_number}_joint2" type="revolute">
             <parent link="leg${leg_number}_link1" />
             <child link="leg${leg_number}_joint_link2" />
-            <origin xyz="${-((leg_link_1_x / 2) + (joint_link_r))}
-                ${(leg_link_1_y / 2) - (joint_link_l / 2)} 0" rpy="0 0 0" />
+            <origin xyz="${-((leg_link1_x / 2) + joint_link_r)}
+                ${(leg_link1_y) - (joint_link_l / 2)} 0" rpy="0 0 0" />
             <limit lower="${joint_lower_limit}"
                    upper="${joint_upper_limit}"
                    effort="${joint_effort_limit}"
@@ -382,25 +383,27 @@
             <axis xyz="0 -1 0" />
         </joint>
         <xacro:leg_transmission leg_number="${leg_number}" joint_number="2" />
-
+        
         <!-- Tibia (Leg Link 2) -->
-        <xacro:millihex_leg_link_2 leg_number="${leg_number}" color="Black" />
-        <!-- leg#_fixed_joint2 -->
+        <xacro:millihex_leg_link2 leg_number="${leg_number}" color="Black" />
+
+        <!-- Fixed Joint 2 -->
         <joint name="leg${leg_number}_fixed_joint2" type="fixed">
             <parent link="leg${leg_number}_joint_link2" />
             <child link="leg${leg_number}_link2" />
-            <origin xyz="${-((leg_link_2_x / 2) + (joint_link_r))} 0 0" rpy="0 0 0" />
+            <origin xyz="${-joint_link_r} 0 0" rpy="0 0 0" />
         </joint>
-
-        <!-- Tibia to Tarsus Joint Link (Joint Link 3) -->
+        
+        <!-- Joint Link 3 -->
         <xacro:millihex_joint_link leg_number="${leg_number}" link_number="3"
             yaw="0.0" color="White" />
-        <!-- leg#_joint3 -->
+
+        <!-- Joint 3 -->
         <joint name="leg${leg_number}_joint3" type="revolute">
             <parent link="leg${leg_number}_link2" />
             <child link="leg${leg_number}_joint_link3" />
-            <origin xyz="${-(leg_link_2_x / 2) + (joint_link_l / 2)}
-                ${(leg_link_2_y / 2) + (joint_link_r)} 0" rpy="0 0 0" />
+            <origin xyz="${-(leg_link2_x) + (joint_link_l / 2)}
+                ${(leg_link2_y / 2) + joint_link_r} 0" rpy="0 0 0" />
             <limit lower="${joint_lower_limit}"
                    upper="${joint_upper_limit}"
                    effort="${joint_effort_limit}"
@@ -410,12 +413,13 @@
         <xacro:leg_transmission leg_number="${leg_number}" joint_number="3" />
 
         <!-- Tarsus (Leg Link 3) -->
-        <xacro:millihex_leg_link_3 leg_number="${leg_number}" color="Orange" />
-        <!-- leg#_fixed_joint3 -->
+        <xacro:millihex_leg_link3 leg_number="${leg_number}" color="Orange" />
+
+        <!-- Fixed Joint 3 -->
         <joint name="leg${leg_number}_fixed_joint3" type="fixed">
             <parent link="leg${leg_number}_joint_link3" />
             <child link="leg${leg_number}_link3" />
-            <origin xyz="0 ${(leg_link_3_y / 2) + (joint_link_r)} 0" rpy="0 0 0" />
+            <origin xyz="0 ${joint_link_r} 0" rpy="0 0 0" />
         </joint>
     </xacro:macro>
 
@@ -429,7 +433,7 @@
         <joint name="leg1_coxa_joint" type="fixed">
             <parent link="thorax" />
             <child link="leg1_coxa" />
-            <origin xyz="${frontal_leg_x} ${right_side_y} 0" rpy="0 0 0" />
+            <origin xyz="${frontal_leg_x} ${thorax_y / 2} 0" rpy="0 0 0" />
         </joint>
 
         <!-- Leg 2 -->
@@ -437,7 +441,7 @@
         <joint name="leg2_coxa_joint" type="fixed">
             <parent link="thorax" />
             <child link="leg2_coxa" />
-            <origin xyz="${medial_leg_x} ${right_side_y} 0" rpy="0 0 0" />
+            <origin xyz="${medial_leg_x} ${thorax_y / 2} 0" rpy="0 0 0" />
         </joint>
 
         <!-- Leg 3 -->
@@ -445,7 +449,7 @@
         <joint name="leg3_coxa_joint" type="fixed">
             <parent link="thorax" />
             <child link="leg3_coxa" />
-            <origin xyz="${hind_leg_x} ${right_side_y} 0" rpy="0 0 0" />
+            <origin xyz="${hind_leg_x} ${thorax_y / 2} 0" rpy="0 0 0" />
         </joint>
 
         <!-- Leg 4 -->
@@ -453,7 +457,7 @@
         <joint name="leg4_coxa_joint" type="fixed">
             <parent link="thorax" />
             <child link="leg4_coxa" />
-            <origin xyz="${frontal_leg_x} ${left_side_y} 0" rpy="${pi} 0 0" />
+            <origin xyz="${frontal_leg_x} ${-thorax_y / 2} 0" rpy="${pi} 0 0" />
         </joint>
 
         <!-- Leg 5 -->
@@ -461,7 +465,7 @@
         <joint name="leg5_coxa_joint" type="fixed">
             <parent link="thorax" />
             <child link="leg5_coxa" />
-            <origin xyz="${medial_leg_x} ${left_side_y} 0" rpy="${pi} 0 0" />
+            <origin xyz="${medial_leg_x} ${-thorax_y / 2} 0" rpy="${pi} 0 0" />
         </joint>
 
         <!-- Leg 6 -->
@@ -469,7 +473,7 @@
         <joint name="leg6_coxa_joint" type="fixed">
             <parent link="thorax" />
             <child link="leg6_coxa" />
-            <origin xyz="${hind_leg_x} ${left_side_y} 0" rpy="${pi} 0 0" />
+            <origin xyz="${hind_leg_x} ${-thorax_y / 2} 0" rpy="${pi} 0 0" />
         </joint>
     </xacro:macro>
 

--- a/robot/millihex_description.xacro
+++ b/robot/millihex_description.xacro
@@ -18,8 +18,8 @@
     <xacro:property name="pcb_thickness_z" value="0.003" />  <!-- PCB thickness (m) -->
 
     <!-- Thorax Properties -->
-    <xacro:property name="thorax_x" value="0.20" />     <!-- x length (m) -->
-    <xacro:property name="thorax_y" value="0.03" />     <!-- y length (m) -->
+    <xacro:property name="thorax_x" value="0.25" />     <!-- x length (m) -->
+    <xacro:property name="thorax_y" value="0.02" />     <!-- y length (m) -->
     <xacro:property name="thorax_kp" value="1000.0" />  <!-- contact stiffness -->
     <xacro:property name="thorax_kd" value="1000.0" />  <!-- contact damping -->
     <xacro:property name="thorax_mu1" value="10.0" />   <!-- friction coef 1 -->
@@ -80,12 +80,12 @@
     <xacro:property name="joint_link_l" value="0.01" />    <!-- length (m) -->
 
     <!-- Revolute Joint Properties -->
-    <xacro:property name="joint_upper_limit" value="1.5708" />   <!-- (rad) -->
-    <xacro:property name="joint_lower_limit" value="-1.5708" />  <!-- (rad) -->
-    <xacro:property name="joint_effort_limit" value="0.1" />     <!-- (rad/s) -->
-    <xacro:property name="joint_velocity_limit" value="0.1" />   <!-- (rad/s) -->
-    <xacro:property name="joint_damping" value="0.0" />          <!-- damping (N*m*s/rad)-->
-    <xacro:property name="joint_friction" value="0.0" />         <!-- friction (N*m) -->
+    <xacro:property name="joint_upper_limit" value="${pi / 2}" />   <!-- (rad) -->
+    <xacro:property name="joint_lower_limit" value="${-pi / 2}" />  <!-- (rad) -->
+    <xacro:property name="joint_effort_limit" value="0.1" />        <!-- (rad/s) -->
+    <xacro:property name="joint_velocity_limit" value="0.1" />      <!-- (rad/s) -->
+    <xacro:property name="joint_damping" value="0.0" />   <!-- damping (N*m*s/rad)-->
+    <xacro:property name="joint_friction" value="0.0" />  <!-- friction (N*m) -->
 
     <!-- Color Definitions -->
     <material name="Black">
@@ -218,6 +218,76 @@
         </gazebo>
     </xacro:macro>
 
+    <!-- Tibia (Leg Link 2) Definition -->
+    <xacro:macro name="millihex_leg_link_2" params="leg_number color">
+        <!-- Tibia (Leg Link 2) Geometry -->
+        <link name="leg${leg_number}_link2">
+            <inertial>
+                <origin xyz="0 0 ${pcb_thickness_z / 2}" rpy="0 0 0" />
+                <mass value="${leg_link_2_mass}" />
+                <xacro:box_inertia mass="${leg_link_2_mass}" x="${leg_link_2_x}"
+                    y="${leg_link_2_y}" z="${pcb_thickness_z}" />
+            </inertial>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="${leg_link_2_x} ${leg_link_2_y} ${pcb_thickness_z}" />
+                </geometry>
+            </collision>
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="${leg_link_2_x} ${leg_link_2_y} ${pcb_thickness_z}" />
+                </geometry>
+                <material name="${color}"/>
+            </visual>
+        </link>
+
+        <!-- Gazebo properties -->
+        <gazebo reference="leg${leg_number}_link2">
+            <kp>${leg_link_2_kp}</kp>
+            <kd>${leg_link_2_kd}</kd>
+            <mu1>${leg_link_2_mu1}</mu1>
+            <mu2>${leg_link_2_mu2}</mu2>
+            <material>Gazebo/${color}</material>
+        </gazebo>
+    </xacro:macro>
+
+    <!-- Tarsus (Leg Link 3) Definition -->
+    <xacro:macro name="millihex_leg_link_3" params="leg_number color">
+        <!-- Tarsus (Leg Link 3) Geometry -->
+        <link name="leg${leg_number}_link3">
+            <inertial>
+                <origin xyz="0 0 ${pcb_thickness_z / 2}" rpy="0 0 0" />
+                <mass value="${leg_link_3_mass}" />
+                <xacro:box_inertia mass="${leg_link_3_mass}" x="${leg_link_3_x}"
+                    y="${leg_link_3_y}" z="${pcb_thickness_z}" />
+            </inertial>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="${leg_link_3_x} ${leg_link_3_y} ${pcb_thickness_z}" />
+                </geometry>
+            </collision>
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="${leg_link_3_x} ${leg_link_3_y} ${pcb_thickness_z}" />
+                </geometry>
+                <material name="${color}"/>
+            </visual>
+        </link>
+
+        <!-- Gazebo properties -->
+        <gazebo reference="leg${leg_number}_link3">
+            <kp>${leg_link_3_kp}</kp>
+            <kd>${leg_link_3_kd}</kd>
+            <mu1>${leg_link_3_mu1}</mu1>
+            <mu2>${leg_link_3_mu2}</mu2>
+            <material>Gazebo/${color}</material>
+        </gazebo>
+    </xacro:macro>
+
     <!-- Joint Link Definition -->
     <xacro:macro name="millihex_joint_link"
         params="leg_number link_number yaw color">
@@ -292,6 +362,59 @@
             <child link="leg${leg_number}_link1" />
             <origin xyz="0 ${(leg_link_1_y / 2) + (joint_link_r)} 0" rpy="0 0 0" />
         </joint>
+
+        <!-- Femur to Tibia Joint Link (Joint Link 2) -->
+        <xacro:millihex_joint_link leg_number="${leg_number}" link_number="2"
+            yaw="${pi / 2}" color="White" />
+        <!-- leg#_joint2 -->
+        <joint name="leg${leg_number}_joint2" type="revolute">
+            <parent link="leg${leg_number}_link1" />
+            <child link="leg${leg_number}_joint_link2" />
+            <origin xyz="${-((leg_link_1_x / 2) + (joint_link_r))}
+                ${(leg_link_1_y / 2) - (joint_link_l / 2)} 0" rpy="0 0 0" />
+            <dynamics damping="${joint_damping}" friction="${joint_friction}" />
+            <limit lower="${joint_lower_limit}"
+                   upper="${joint_upper_limit}"
+                   effort="${joint_effort_limit}"
+                   velocity="${joint_velocity_limit}" />
+            <axis xyz="0 1 0" />
+        </joint>
+        <xacro:leg_transmission leg_number="${leg_number}" joint_number="2" />
+
+        <!-- Tibia (Leg Link 2) -->
+        <xacro:millihex_leg_link_2 leg_number="${leg_number}" color="Black" />
+        <!-- leg#_fixed_joint2 -->
+        <joint name="leg${leg_number}_fixed_joint2" type="fixed">
+            <parent link="leg${leg_number}_joint_link2" />
+            <child link="leg${leg_number}_link2" />
+            <origin xyz="${-((leg_link_2_x / 2) + (joint_link_r))} 0 0" rpy="0 0 0" />
+        </joint>
+
+        <!-- Tibia to Tarsus Joint Link (Joint Link 3) -->
+        <xacro:millihex_joint_link leg_number="${leg_number}" link_number="3"
+            yaw="0.0" color="White" />
+        <!-- leg#_joint3 -->
+        <joint name="leg${leg_number}_joint3" type="revolute">
+            <parent link="leg${leg_number}_link2" />
+            <child link="leg${leg_number}_joint_link3" />
+            <origin xyz="${-(leg_link_2_x / 2) + (joint_link_l / 2)} ${(leg_link_2_y / 2) + (joint_link_r)} 0" rpy="0 0 0" />
+            <dynamics damping="${joint_damping}" friction="${joint_friction}" />
+            <limit lower="${joint_lower_limit}"
+                   upper="${joint_upper_limit}"
+                   effort="${joint_effort_limit}"
+                   velocity="${joint_velocity_limit}" />
+            <axis xyz="1 0 0" />
+        </joint>
+        <xacro:leg_transmission leg_number="${leg_number}" joint_number="3" />
+
+        <!-- Tarsus (Leg Link 3) -->
+        <xacro:millihex_leg_link_3 leg_number="${leg_number}" color="Orange" />
+        <!-- leg#_fixed_joint3 -->
+        <joint name="leg${leg_number}_fixed_joint3" type="fixed">
+            <parent link="leg${leg_number}_joint_link3" />
+            <child link="leg${leg_number}_link3" />
+            <origin xyz="0 ${(leg_link_3_y / 2) + (joint_link_r)} 0" rpy="0 0 0" />
+        </joint>
     </xacro:macro>
 
     <!-- Assemble Body -->
@@ -305,6 +428,46 @@
             <parent link="thorax" />
             <child link="leg1_coxa" />
             <origin xyz="${frontal_leg_x} ${right_side_y} 0" rpy="0 0 0" />
+        </joint>
+
+        <!-- Leg 2 -->
+        <xacro:millihex_leg leg_number="2" />
+        <joint name="leg2_coxa_joint" type="fixed">
+            <parent link="thorax" />
+            <child link="leg2_coxa" />
+            <origin xyz="${medial_leg_x} ${right_side_y} 0" rpy="0 0 0" />
+        </joint>
+
+        <!-- Leg 3 -->
+        <xacro:millihex_leg leg_number="3" />
+        <joint name="leg3_coxa_joint" type="fixed">
+            <parent link="thorax" />
+            <child link="leg3_coxa" />
+            <origin xyz="${hind_leg_x} ${right_side_y} 0" rpy="0 0 0" />
+        </joint>
+
+        <!-- Leg 4 -->
+        <xacro:millihex_leg leg_number="4" />
+        <joint name="leg4_coxa_joint" type="fixed">
+            <parent link="thorax" />
+            <child link="leg4_coxa" />
+            <origin xyz="${frontal_leg_x} ${left_side_y} 0" rpy="${pi} 0 0" />
+        </joint>
+
+        <!-- Leg 5 -->
+        <xacro:millihex_leg leg_number="5" />
+        <joint name="leg5_coxa_joint" type="fixed">
+            <parent link="thorax" />
+            <child link="leg5_coxa" />
+            <origin xyz="${medial_leg_x} ${left_side_y} 0" rpy="${pi} 0 0" />
+        </joint>
+
+        <!-- Leg 6 -->
+        <xacro:millihex_leg leg_number="6" />
+        <joint name="leg6_coxa_joint" type="fixed">
+            <parent link="thorax" />
+            <child link="leg6_coxa" />
+            <origin xyz="${hind_leg_x} ${left_side_y} 0" rpy="${pi} 0 0" />
         </joint>
     </xacro:macro>
 

--- a/robot/millihex_description.xacro
+++ b/robot/millihex_description.xacro
@@ -14,36 +14,36 @@
     </xacro:macro>
 
     <!-- PCB Properties -->
-    <xacro:property name="pcb_density" value="1850" />       <!-- FR4 density (kg/m^3) -->
+    <xacro:property name="pcb_density" value="2000" />       <!-- FR4 density (kg/m^3) -->
     <xacro:property name="pcb_thickness_z" value="0.002" />  <!-- PCB thickness (m) -->
 
     <!-- Thorax Properties -->
-    <xacro:property name="thorax_x" value="0.25" />     <!-- x length (m) -->
+    <xacro:property name="thorax_x" value="0.17" />     <!-- x length (m) -->
     <xacro:property name="thorax_y" value="0.02" />     <!-- y length (m) -->
     <xacro:property name="thorax_mass"
         value="${pcb_density * (thorax_x * thorax_y * pcb_thickness_z)}" />  <!-- (kg) -->
     
     <!-- Coxa Properties -->
-    <xacro:property name="coxa_x" value="0.01" />     <!-- x length (m) -->
-    <xacro:property name="coxa_y" value="0.01" />     <!-- y length (m) -->
+    <xacro:property name="coxa_x" value="0.015" />     <!-- x length (m) -->
+    <xacro:property name="coxa_y" value="0.015" />     <!-- y length (m) -->
     <xacro:property name="coxa_mass"
         value="${pcb_density * (coxa_x * coxa_y * pcb_thickness_z)}" />  <!-- (kg) -->
 
     <!-- Femur (Leg Link 1) Properties -->
-    <xacro:property name="leg_link1_x" value="0.01" />     <!-- x length (m) -->
-    <xacro:property name="leg_link1_y" value="0.05" />     <!-- y length (m) -->
+    <xacro:property name="leg_link1_x" value="0.015" />     <!-- x length (m) -->
+    <xacro:property name="leg_link1_y" value="0.03" />     <!-- y length (m) -->
     <xacro:property name="leg_link1_mass"
         value="${pcb_density * (leg_link1_x * leg_link1_y * pcb_thickness_z)}" />  <!-- (kg) -->
 
     <!-- Tibia (Leg Link 2) Properties -->
-    <xacro:property name="leg_link2_x" value="0.05" />     <!-- x length (m) -->
-    <xacro:property name="leg_link2_y" value="0.01" />     <!-- y length (m) -->
+    <xacro:property name="leg_link2_x" value="0.02" />     <!-- x length (m) -->
+    <xacro:property name="leg_link2_y" value="0.015" />     <!-- y length (m) -->
     <xacro:property name="leg_link2_mass"
         value="${pcb_density * (leg_link2_x * leg_link2_y * pcb_thickness_z)}" />  <!-- (kg) -->
 
     <!-- Tarsus (Leg Link 3) Properties -->
-    <xacro:property name="leg_link3_x" value="0.01" />     <!-- x length (m) -->
-    <xacro:property name="leg_link3_y" value="0.05" />     <!-- y length (m) -->
+    <xacro:property name="leg_link3_x" value="0.015" />     <!-- x length (m) -->
+    <xacro:property name="leg_link3_y" value="0.03" />     <!-- y length (m) -->
     <xacro:property name="leg_link3_mass"
         value="${pcb_density * (leg_link3_x * leg_link3_y * pcb_thickness_z)}" />  <!-- (kg) -->
         
@@ -54,16 +54,18 @@
         value="${pcb_density * (pi * (joint_link_r * joint_link_r) * joint_link_l)}" />  <!-- (kg) -->
 
     <!-- Link Friction and -->
-    <xacro:property name="link_kp" value="1000000.0" />  <!-- Contact stiffness -->
-    <xacro:property name="link_kd" value="100.0" />        <!-- Contact damping -->
-    <xacro:property name="link_mu1" value="100.0" />     <!-- Friction coefficient 1 -->
-    <xacro:property name="link_mu2" value="100.0" />     <!-- Friction coefficient 2 -->
+    <xacro:property name="link_kp" value="1000.0" />  <!-- Contact stiffness -->
+    <xacro:property name="link_kd" value="1.0" />        <!-- Contact damping -->
+    <xacro:property name="link_mu1" value="10.0" />     <!-- Friction coefficient 1 -->
+    <xacro:property name="link_mu2" value="10.0" />     <!-- Friction coefficient 2 -->
 
-    <!-- Revolute Joint Limits -->
+    <!-- Revolute Joint Properties -->
     <xacro:property name="joint_upper_limit" value="${pi / 2}" />   <!-- (rad) -->
     <xacro:property name="joint_lower_limit" value="${-pi / 2}" />  <!-- (rad) -->
     <xacro:property name="joint_effort_limit" value="1.0" />        <!-- (N*m) -->
     <xacro:property name="joint_velocity_limit" value="1.0" />      <!-- (rad/s) -->
+    <xacro:property name="joint_damping" value="4.6e-6" />        <!-- (N*m*s/rad) -->
+    <xacro:property name="joint_friction" value="0.0" />            <!-- (N*m) -->
     
     <!-- Thorax Leg Joint Attachment Positions -->
     <xacro:property name="leg_spacing" value="${(2 * coxa_x) + leg_link2_x}" />
@@ -186,13 +188,13 @@
                     y="${leg_link1_y}" z="${pcb_thickness_z}" />
             </inertial>
             <collision>
-                <origin xyz="0 ${leg_link1_y / 2} 0" rpy="0 0 0" />
+                <origin xyz="0 ${(leg_link1_y / 2) + joint_link_r} 0" rpy="0 0 0" />
                 <geometry>
                     <box size="${leg_link1_x} ${leg_link1_y} ${pcb_thickness_z}" />
                 </geometry>
             </collision>
             <visual>
-                <origin xyz="0 ${leg_link1_y / 2} 0" rpy="0 0 0" />
+                <origin xyz="0 ${(leg_link1_y / 2) + joint_link_r} 0" rpy="0 0 0" />
                 <geometry>
                     <box size="${leg_link1_x} ${leg_link1_y} ${pcb_thickness_z}" />
                 </geometry>
@@ -221,13 +223,13 @@
                     y="${leg_link2_y}" z="${pcb_thickness_z}" />
             </inertial>
             <collision>
-                <origin xyz="${-leg_link2_x / 2} 0 0" rpy="0 0 0" />
+                <origin xyz="${-((leg_link2_x / 2) + joint_link_r)} 0 0" rpy="0 0 0" />
                 <geometry>
                     <box size="${leg_link2_x} ${leg_link2_y} ${pcb_thickness_z}" />
                 </geometry>
             </collision>
             <visual>
-                <origin xyz="${-leg_link2_x / 2} 0 0" rpy="0 0 0" />
+                <origin xyz="${-((leg_link2_x / 2) + joint_link_r)} 0 0" rpy="0 0 0" />
                 <geometry>
                     <box size="${leg_link2_x} ${leg_link2_y} ${pcb_thickness_z}" />
                 </geometry>
@@ -256,13 +258,13 @@
                     y="${leg_link3_y}" z="${pcb_thickness_z}" />
             </inertial>
             <collision>
-                <origin xyz="0 ${leg_link3_y / 2} 0" rpy="0 0 0" />
+                <origin xyz="0 ${(leg_link3_y / 2) + joint_link_r} 0" rpy="0 0 0" />
                 <geometry>
                     <box size="${leg_link3_x} ${leg_link3_y} ${pcb_thickness_z}" />
                 </geometry>
             </collision>
             <visual>
-                <origin xyz="0 ${leg_link3_y / 2} 0" rpy="0 0 0" />
+                <origin xyz="0 ${(leg_link3_y / 2) + joint_link_r} 0" rpy="0 0 0" />
                 <geometry>
                     <box size="${leg_link3_x} ${leg_link3_y} ${pcb_thickness_z}" />
                 </geometry>
@@ -291,12 +293,6 @@
                 <xacro:cylinder_inerta mass="${joint_link_mass}"
                     r="${joint_link_r}" l="${joint_link_l}" />
             </inertial>
-            <collision>
-                <origin xyz="0 0 0" rpy="0 0 0" />
-                <geometry>
-                    <cylinder radius="${joint_link_r}" length="${joint_link_l}" />
-                </geometry>
-            </collision>
             <visual>
                 <origin xyz="0 0 0" rpy="0 ${pi / 2} ${yaw}" />
                 <geometry>
@@ -348,6 +344,7 @@
             <parent link="leg${leg_number}_coxa" />
             <child link="leg${leg_number}_joint_link1" />
             <origin xyz="0 ${coxa_y + joint_link_r} 0" rpy="0 0 0" />
+            <dynamics damping="${joint_damping}" friction="${joint_friction}"/>
             <limit lower="${joint_lower_limit}"
                    upper="${joint_upper_limit}"
                    effort="${joint_effort_limit}"
@@ -363,7 +360,7 @@
         <joint name="leg${leg_number}_fixed_joint1" type="fixed">
             <parent link="leg${leg_number}_joint_link1" />
             <child link="leg${leg_number}_link1" />
-            <origin xyz="0 ${joint_link_r} 0" rpy="0 0 0" />
+            <origin xyz="0 0 0" rpy="0 0 0" />
         </joint>
 
         <!-- Joint Link 2 -->
@@ -375,7 +372,9 @@
             <parent link="leg${leg_number}_link1" />
             <child link="leg${leg_number}_joint_link2" />
             <origin xyz="${-((leg_link1_x / 2) + joint_link_r)}
-                ${(leg_link1_y) - (joint_link_l / 2)} 0" rpy="0 0 0" />
+                ${(leg_link1_y) - (joint_link_l / 2) + joint_link_r} 0"
+                rpy="0 0 0" />
+            <dynamics damping="${joint_damping}" friction="${joint_friction}"/>
             <limit lower="${joint_lower_limit}"
                    upper="${joint_upper_limit}"
                    effort="${joint_effort_limit}"
@@ -391,7 +390,7 @@
         <joint name="leg${leg_number}_fixed_joint2" type="fixed">
             <parent link="leg${leg_number}_joint_link2" />
             <child link="leg${leg_number}_link2" />
-            <origin xyz="${-joint_link_r} 0 0" rpy="0 0 0" />
+            <origin xyz="0 0 0" rpy="0 0 0" />
         </joint>
         
         <!-- Joint Link 3 -->
@@ -402,8 +401,9 @@
         <joint name="leg${leg_number}_joint3" type="revolute">
             <parent link="leg${leg_number}_link2" />
             <child link="leg${leg_number}_joint_link3" />
-            <origin xyz="${-(leg_link2_x) + (joint_link_l / 2)}
+            <origin xyz="${-(leg_link2_x) + (joint_link_l / 2) - joint_link_r}
                 ${(leg_link2_y / 2) + joint_link_r} 0" rpy="0 0 0" />
+            <dynamics damping="${joint_damping}" friction="${joint_friction}"/>
             <limit lower="${joint_lower_limit}"
                    upper="${joint_upper_limit}"
                    effort="${joint_effort_limit}"
@@ -419,7 +419,7 @@
         <joint name="leg${leg_number}_fixed_joint3" type="fixed">
             <parent link="leg${leg_number}_joint_link3" />
             <child link="leg${leg_number}_link3" />
-            <origin xyz="0 ${joint_link_r} 0" rpy="0 0 0" />
+            <origin xyz="0 0 0" rpy="0 0 0" />
         </joint>
     </xacro:macro>
 

--- a/robot/millihex_description.xacro
+++ b/robot/millihex_description.xacro
@@ -44,6 +44,8 @@
     <!-- Tarsus (Leg Link 3) Properties -->
     <xacro:property name="leg_link_3_x" value="0.01" />     <!-- x length (m) -->
     <xacro:property name="leg_link_3_y" value="0.05" />     <!-- y length (m) -->
+    <xacro:property name="foot_mu1" value="100.0" />          <!-- friction coefficient 1 -->
+    <xacro:property name="foot_mu2" value="100.0" />          <!-- friction coefficient 2 -->
     <xacro:property name="leg_link_3_mass"
         value="${pcb_density * (leg_link_3_x * leg_link_3_y * pcb_thickness_z)}" />  <!-- (kg) -->
         
@@ -56,7 +58,7 @@
     <!-- Revolute Joint Properties -->
     <xacro:property name="joint_upper_limit" value="${pi / 2}" />   <!-- (rad) -->
     <xacro:property name="joint_lower_limit" value="${-pi / 2}" />  <!-- (rad) -->
-    <xacro:property name="joint_effort_limit" value="0.1" />        <!-- (N*m) -->
+    <xacro:property name="joint_effort_limit" value="1.0" />        <!-- (N*m) -->
     <xacro:property name="joint_velocity_limit" value="0.1" />      <!-- (rad/s) -->
     
     <!-- Thorax Leg Joint Attachment Positions -->
@@ -252,6 +254,8 @@
 
         <!-- Gazebo properties -->
         <gazebo reference="leg${leg_number}_link3">
+            <mu1>${foot_mu1}</mu1>
+            <mu2>${foot_mu2}</mu2>
             <material>Gazebo/${color}</material>
         </gazebo>
     </xacro:macro>

--- a/robot/millihex_description.xacro
+++ b/robot/millihex_description.xacro
@@ -7,19 +7,23 @@
     <!-- PCB density ~= FR4 density (kg/m^3) -->
     <!-- PCB thickness (m) -->
     <xacro:property name="pcb_density" value="1850" />
-    <xacro:property name="pcb_thickness_z" value="0.0015" />
+    <xacro:property name="pcb_thickness_z" value="0.003" />
 
-    <!-- Torso x,y dimensions (m) and mass (kg) -->
+    <!-- Torso Link x,y dimensions (m) and mass (kg) -->
     <xacro:property name="torso_x" value="0.14" />
     <xacro:property name="torso_y" value="0.04" />
     <xacro:property name="torso_mass"
         value="${pcb_density * torso_x * torso_y * pcb_thickness_z}" />
 
-    <!-- Leg x,y dimensions (m) -->
+    <!-- Leg Link x,y dimensions (m) and mass (kg) -->
     <xacro:property name="leg_link_x" value="0.02" />
     <xacro:property name="leg_link_y" value="0.03" />
     <xacro:property name="leg_link_mass"
         value="${pcb_density * leg_link_x * leg_link_y * pcb_thickness_z}" />
+
+    <!-- Massless Joint Link x,y dimensions (m) -->
+    <xacro:property name="joint_link_r" value="${pcb_thickness_z / 2}" />
+    <xacro:property name="joint_link_l" value="${leg_link_x}"
 
     <!-- Joint limits (rad) -->
     <xacro:property name="joint_upper_limit" value="1.5708" />

--- a/robot/millihex_description.xacro
+++ b/robot/millihex_description.xacro
@@ -20,8 +20,8 @@
         value="${pcb_density * (thorax_x * thorax_y * pcb_thickness_z)}" />  <!-- (kg) -->
     
     <!-- Coxa Properties -->
-    <xacro:property name="coxa_x" value="0.14" />     <!-- x length (m) -->
-    <xacro:property name="coxa_y" value="0.04" />     <!-- y length (m) -->
+    <xacro:property name="coxa_x" value="0.01" />     <!-- x length (m) -->
+    <xacro:property name="coxa_y" value="0.01" />     <!-- y length (m) -->
     <xacro:property name="coxa_kp" value="1000.0" />  <!-- contact stiffness -->
     <xacro:property name="coxa_kd" value="1000.0" />  <!-- contact damping -->
     <xacro:property name="coxa_mu1" value="10.0" />   <!-- friction coef 1 -->
@@ -30,8 +30,8 @@
         value="${pcb_density * (coxa_x * coxa_y * pcb_thickness_z)}" />  <!-- (kg) -->
 
     <!-- Femur (Leg Link 1) Properties -->
-    <xacro:property name="leg_link_1_x" value="0.02" />     <!-- x length (m) -->
-    <xacro:property name="leg_link_1_y" value="0.03" />     <!-- y length (m) -->
+    <xacro:property name="leg_link_1_x" value="0.01" />     <!-- x length (m) -->
+    <xacro:property name="leg_link_1_y" value="0.05" />     <!-- y length (m) -->
     <xacro:property name="leg_link_1_kp" value="1000.0" />  <!-- contact stiffness -->
     <xacro:property name="leg_link_1_kd" value="1000.0" />  <!-- contact damping -->
     <xacro:property name="leg_link_1_mu1" value="10.0" />   <!-- friction coef 1 -->
@@ -40,8 +40,8 @@
         value="${pcb_density * (leg_link_1_x * leg_link_2_y * pcb_thickness_z)}" />  <!-- (kg) -->
 
     <!-- Tibia (Leg Link 2) Properties -->
-    <xacro:property name="leg_link_2_x" value="0.02" />     <!-- x length (m) -->
-    <xacro:property name="leg_link_2_y" value="0.03" />     <!-- y length (m) -->
+    <xacro:property name="leg_link_2_x" value="0.05" />     <!-- x length (m) -->
+    <xacro:property name="leg_link_2_y" value="0.01" />     <!-- y length (m) -->
     <xacro:property name="leg_link_2_kp" value="1000.0" />  <!-- contact stiffness -->
     <xacro:property name="leg_link_2_kd" value="1000.0" />  <!-- contact damping -->
     <xacro:property name="leg_link_2_mu1" value="10.0" />   <!-- friction coef 1 -->
@@ -50,8 +50,8 @@
         value="${pcb_density * (leg_link_2_x * leg_link_2_y * pcb_thickness_z)}" />  <!-- (kg) -->
 
     <!-- Tarsus (Leg Link 3) Properties -->
-    <xacro:property name="leg_link_3_x" value="0.02" />     <!-- x length (m) -->
-    <xacro:property name="leg_link_3_y" value="0.03" />     <!-- y length (m) -->
+    <xacro:property name="leg_link_3_x" value="0.01" />     <!-- x length (m) -->
+    <xacro:property name="leg_link_3_y" value="0.05" />     <!-- y length (m) -->
     <xacro:property name="leg_link_3_kp" value="1000.0" />  <!-- contact stiffness -->
     <xacro:property name="leg_link_3_kd" value="1000.0" />  <!-- contact damping -->
     <xacro:property name="leg_link_3_mu1" value="10.0" />   <!-- friction coef 1 -->
@@ -60,8 +60,8 @@
         value="${pcb_density * (leg_link_3_x * leg_link_3_y * pcb_thickness_z)}" />  <!-- (kg) -->
         
     <!-- Joint Link Properties -->
-    <xacro:property name="joint_link_r" value="${pcb_thickness_z / 2}" />  <!-- radius (m) -->
-    <xacro:property name="joint_link_l" value="${leg_link_x}" />           <!-- length (m) -->
+    <xacro:property name="joint_link_r" value="0.0015" />  <!-- radius (m) -->
+    <xacro:property name="joint_link_l" value="0.01" />    <!-- length (m) -->
 
     <!-- Revolute Joint Properties -->
     <xacro:property name="joint_upper_limit" value="1.5708" />   <!-- (rad) -->
@@ -134,74 +134,102 @@
         </joint>
     </xacro:macro>
 
+    <!-- Coxa Definition -->
+    <xacro:macro name="millihex_coxa" params="leg_number color">
+
+        <!-- Coxa Geometry -->
+        <link name="leg${leg_number}_coxa">
+            <inertial>
+                <origin xyz="0 0 ${pcb_thickness_z / 2}" rpy="0 0 0" />
+                <mass value="${coxa_mass}" />
+                <xacro:box_inertia mass="${coxa_mass}" x="${coxa_x}"
+                    y="${coxa_y}" z="${pcb_thickness_z}" />
+            </inertial>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="${coxa_x} ${coxa_y} ${pcb_thickness_z}" />
+                </geometry>
+            </collision>
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="${coxa_x} ${coxa_y} ${pcb_thickness_z}" />
+                </geometry>
+                <material name="${color}"/>
+            </visual>
+        </link>
+
+        <!-- Gazebo properties -->
+        <gazebo reference="leg${leg_number}_coxa">
+            <kp>${coxa_kp}</kp>
+            <kd>${coxa_kd}</kd>
+            <mu1>${coxa_mu1}</mu1>
+            <mu2>${coxa_mu2}</mu2>
+            <material>Gazebo/${color}</material>
+        </gazebo>
+    </xacro:macro>
+
+    <!-- Femur (Leg Link 1) Definition -->
+    <xacro:macro name="millihex_leg_link_1" params="leg_number color">
+
+        <!-- Femur (Leg Link 1) Geometry -->
+        <link name="leg${leg_number}_link1">
+            <inertial>
+                <origin xyz="0 0 ${pcb_thickness_z / 2}" rpy="0 0 0" />
+                <mass value="${leg_link_1_mass}" />
+                <xacro:box_inertia mass="${leg_link_1_mass}" x="${leg_link_1_x}"
+                    y="${leg_link_1_y}" z="${pcb_thickness_z}" />
+            </inertial>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="${leg_link_1_x} ${leg_link_1_y} ${pcb_thickness_z}" />
+                </geometry>
+            </collision>
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="${leg_link_1_x} ${leg_link_1_y} ${pcb_thickness_z}" />
+                </geometry>
+                <material name="${color}"/>
+            </visual>
+        </link>
+
+        <!-- Gazebo properties -->
+        <gazebo reference="leg${leg_number}_link1">
+            <kp>${leg_link_1_kp}</kp>
+            <kd>${leg_link_1_kd}</kd>
+            <mu1>${leg_link_1_mu1}</mu1>
+            <mu2>${leg_link_1_mu2}</mu2>
+            <material>Gazebo/${color}</material>
+        </gazebo>
+    </xacro:macro>
 
     <!-- Joint Link Definition -->
     <xacro:macro name="millihex_joint_link" params="leg_number link_number color">
         <!-- Joint Link Geometry -->
         <link name="leg${leg_number}_joint_link${link_number}">
             <collision>
-                <origin xyz="-${x_length / 2} -${y_length / 2} 0" rpy="0 0 0" />
+                <origin xyz="0 0 0" rpy="0 0 0" />
                 <geometry>
-                    <cylinder radius="${fake_joint_link_r}"
-                        length="${fake_joint_link_l}" />
+                    <cylinder radius="${joint_link_r}" length="${joint_link_l}" />
                 </geometry>
             </collision>
             <visual>
-                <origin xyz="-${x_length / 2} -${y_length / 2} 0" rpy="0 0 0" />
+                <origin xyz="0 0 0" rpy="0 0 0" />
                 <geometry>
-                    <box size="${x_length} ${y_length} ${pcb_thickness_z}" />
+                    <cylinder radius="${joint_link_r}" length="${joint_link_l}" />
                 </geometry>
                 <material name="${color}"/>
             </visual>
         </link>
 
         <!-- Gazebo properties -->
-        <gazebo reference="leg${leg_number}_link${link_number}">
-            <kp>${link_kp}</kp>
-            <kd>${link_kd}</kd>
-            <mu1>${link_mu1}</mu1>
-            <mu2>${link_mu2}</mu2>
+        <gazebo reference="leg${leg_number}_joint_link${link_number}">
             <material>Gazebo/${color}</material>
         </gazebo>
     </xacro:macro>
-
-
-    <!-- Leg Link Definition -->
-    <xacro:macro name="millihex_leg_link"
-        params="leg_number link_number x_length y_length color">
-        <!-- Leg Link Geometry -->
-        <link name="leg${leg_number}_link${link_number}">
-            <inertial>
-                <origin xyz="0 0 ${pcb_thickness_z / 2}" rpy="0 0 0" />
-                <mass value="${leg_link_mass}" />
-                <xacro:box_inertia mass="${leg_link_mass}" x="${x_length}"
-                    y="${y_length}" z="${pcb_thickness_z}" />
-            </inertial>
-            <collision>
-                <origin xyz="-${x_length / 2} -${y_length / 2} 0" rpy="0 0 0" />
-                <geometry>
-                    <box size="${x_length} ${y_length} ${pcb_thickness_z}" />
-                </geometry>
-            </collision>
-            <visual>
-                <origin xyz="-${x_length / 2} -${y_length / 2} 0" rpy="0 0 0" />
-                <geometry>
-                    <box size="${x_length} ${y_length} ${pcb_thickness_z}" />
-                </geometry>
-                <material name="${color}"/>
-            </visual>
-        </link>
-
-        <!-- Gazebo properties -->
-        <gazebo reference="leg${leg_number}_link${link_number}">
-            <kp>${link_kp}</kp>
-            <kd>${link_kd}</kd>
-            <mu1>${link_mu1}</mu1>
-            <mu2>${link_mu2}</mu2>
-            <material>Gazebo/${color}</material>
-        </gazebo>
-    </xacro:macro>
-
 
     <!-- Leg Joint Transmission -->
     <xacro:macro name="leg_transmission" params="leg_number joint_number">
@@ -220,7 +248,6 @@
             </actuator>
         </transmission>
     </xacro:macro>
-
   
     <!-- Assemble Leg -->
     <xacro:macro name="millihex_leg" params="leg_number">
@@ -243,16 +270,13 @@
                    velocity="${joint_velocity_limit}" />
             <axis xyz="1 0 0" />
         </joint>
-
         <xacro:leg_transmission leg_number="${leg_number}" joint_number="1" />
-
     </xacro:macro>
-
 
     <!-- Assemble Body -->
     <xacro:macro name="millihex_body" params="">
-        <!-- Call Torso xacro -->
-        <xacro:millihex_torso color="Orange" />
+        <!-- Call Thorax xacro -->
+        <xacro:millihex_thorax color="Orange" />
 
         <!-- Leg 1-->
         <xacro:millihex_leg leg_number="1" />
@@ -262,9 +286,7 @@
             <child link="leg1_link0" />
             <origin xyz="${torso_x / 2} -${torso_y / 2} 0" rpy="0 0 0" />
         </joint>
-    
     </xacro:macro>
-
 
     <!-- Add Gazebo Control Library -->
     <xacro:macro name="millihex_control" params="namespace">
@@ -274,7 +296,6 @@
             </plugin>
         </gazebo>
     </xacro:macro>
-  
 
     <!-- Build Robot and Gazebo Control Library -->
     <xacro:millihex_body />

--- a/robot/millihex_description.xacro
+++ b/robot/millihex_description.xacro
@@ -23,7 +23,7 @@
 
     <!-- Massless Joint Link x,y dimensions (m) -->
     <xacro:property name="joint_link_r" value="${pcb_thickness_z / 2}" />
-    <xacro:property name="joint_link_l" value="${leg_link_x}"
+    <xacro:property name="joint_link_l" value="${leg_link_x}" />
 
     <!-- Joint limits (rad) -->
     <xacro:property name="joint_upper_limit" value="1.5708" />

--- a/robot/millihex_description.xacro
+++ b/robot/millihex_description.xacro
@@ -4,6 +4,14 @@
 <!-- rosrun xacro xacro millihex_description.xacro > millihex_description.urdf -->
 
 <robot name="millihex" xmlns:xacro="http://www.ros.org/wiki/xacro">
+    <!-- Gazebo Control Library -->
+    <xacro:macro name="millihex_control" params="namespace">
+        <gazebo>
+            <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
+                <robotNamespace>/${namespace}</robotNamespace>
+            </plugin>
+        </gazebo>
+    </xacro:macro>
 
     <!-- PCB Properties -->
     <xacro:property name="pcb_density" value="1850" />       <!-- FR4 density (kg/m^3) -->
@@ -58,6 +66,14 @@
     <xacro:property name="leg_link_3_mu2" value="10.0" />   <!-- friction coef 2 -->
     <xacro:property name="leg_link_3_mass"
         value="${pcb_density * (leg_link_3_x * leg_link_3_y * pcb_thickness_z)}" />  <!-- (kg) -->
+
+    <!-- Thorax Leg Joint Attachment Positions -->
+    <xacro:property name="leg_spacing" value="${(2 * coxa_x) + leg_link_2_x}" />
+    <xacro:property name="frontal_leg_x" value="${(thorax_x / 2) - (coxa_x / 2)}" />
+    <xacro:property name="medial_leg_x" value="${frontal_leg_x - leg_spacing}" />
+    <xacro:property name="hind_leg_x" value="${medial_leg_x - leg_spacing}" />
+    <xacro:property name="right_side_y" value="${thorax_y / 2}" />
+    <xacro:property name="left_side_y" value="${-(thorax_y / 2)}" />
         
     <!-- Joint Link Properties -->
     <xacro:property name="joint_link_r" value="0.0015" />  <!-- radius (m) -->
@@ -82,7 +98,6 @@
         <color rgba="0.98 0.41 0.055 1.0" />
     </material>
 
-    <!-- Equation Macros -->
     <!-- Calculate Moment of Inertia of a Box -->
     <xacro:macro name="box_inertia" params="mass x y z">
         <inertia ixx="${mass*(y*y+z*z)/12}" ixy = "0" ixz = "0"
@@ -91,7 +106,6 @@
 
     <!-- Thorax Definition -->
     <xacro:macro name="millihex_thorax" params="color">
-    
         <!-- Dummy Base Link to support KDL -->
         <link name="base_link" />
         
@@ -136,7 +150,6 @@
 
     <!-- Coxa Definition -->
     <xacro:macro name="millihex_coxa" params="leg_number color">
-
         <!-- Coxa Geometry -->
         <link name="leg${leg_number}_coxa">
             <inertial>
@@ -172,7 +185,6 @@
 
     <!-- Femur (Leg Link 1) Definition -->
     <xacro:macro name="millihex_leg_link_1" params="leg_number color">
-
         <!-- Femur (Leg Link 1) Geometry -->
         <link name="leg${leg_number}_link1">
             <inertial>
@@ -231,7 +243,7 @@
         </gazebo>
     </xacro:macro>
 
-    <!-- Leg Joint Transmission -->
+    <!-- Joint Transmission -->
     <xacro:macro name="leg_transmission" params="leg_number joint_number">
         <transmission name="leg${leg_number}_joint${joint_number}_tran">
             <type>transmission_interface/SimpleTransmission</type>
@@ -251,18 +263,15 @@
   
     <!-- Assemble Leg -->
     <xacro:macro name="millihex_leg" params="leg_number">
-        <!-- Link 0 (shoulder link), horizontally oriented -->
-        <xacro:millihex_leg_link leg_number="${leg_number}" link_number="0"
-            x_length="${leg_link_x}" y_length="${leg_link_y}" color="Black" />
+        <!-- Coxa -->
+        <xacro:millihex_coxa leg_number="${leg_number}" color="Black" />
 
-        <!-- Link 1, vertically oriented -->
-        <xacro:millihex_leg_link leg_number="${leg_number}" link_number="1"
-            x_length="${leg_link_y}" y_length="${leg_link_x}" color="Orange" />
-
+        <!-- Coxa to Femur Joint Link (Joint Link 1) -->
+        <xacro:millihex_joint_link leg_number="${leg_number}" link_number="1" color="Cyan" />
+        <!-- leg#_joint1 -->
         <joint name="leg${leg_number}_joint1" type="revolute">
-            <parent link="leg${leg_number}_link0" />
-            <child link="leg${leg_number}_link1" />
-            <origin xyz="0 -${leg_link_y} 0" rpy="0 0 0" />
+            <parent link="leg${leg_number}_coxa" />
+            <child link="leg${leg_number}_joint_link1" />
             <dynamics damping="${joint_damping}" friction="${joint_friction}" />
             <limit lower="${joint_lower_limit}"
                    upper="${joint_upper_limit}"
@@ -271,33 +280,32 @@
             <axis xyz="1 0 0" />
         </joint>
         <xacro:leg_transmission leg_number="${leg_number}" joint_number="1" />
+
+        <!-- Femur (Leg Link 1) -->
+        <xacro:millihex_leg_link_1 leg_number="${leg_number}" color="Orange" />
+        <!-- leg#_fixed_joint1 -->
+        <joint name="leg${leg_number}_fixed_joint1" type="fixed">
+            <parent link="leg${leg_number}_joint_link1" />
+            <child link="leg${leg_number}_link1" />
+            <origin xyz="0 0 0" rpy="0 0 0" />
+        </joint>
     </xacro:macro>
 
     <!-- Assemble Body -->
     <xacro:macro name="millihex_body" params="">
-        <!-- Call Thorax xacro -->
+        <!-- Thorax -->
         <xacro:millihex_thorax color="Orange" />
 
-        <!-- Leg 1-->
+        <!-- Leg 1 -->
         <xacro:millihex_leg leg_number="1" />
-        <!-- Leg 1, Joint 0 (fixed, shoulder joint)-->
-        <joint name="leg1_joint0" type="fixed">
-            <parent link="torso" />
-            <child link="leg1_link0" />
-            <origin xyz="${torso_x / 2} -${torso_y / 2} 0" rpy="0 0 0" />
+        <joint name="leg1_coxa_joint" type="fixed">
+            <parent link="thorax" />
+            <child link="leg1_coxa" />
+            <origin xyz="${frontal_leg_x} ${right_side_y} 0" rpy="0 0 0" />
         </joint>
     </xacro:macro>
 
-    <!-- Add Gazebo Control Library -->
-    <xacro:macro name="millihex_control" params="namespace">
-        <gazebo>
-            <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
-                <robotNamespace>/${namespace}</robotNamespace>
-            </plugin>
-        </gazebo>
-    </xacro:macro>
-
-    <!-- Build Robot and Gazebo Control Library -->
+    <!-- Assemble Robot -->
     <xacro:millihex_body />
     <xacro:millihex_control namespace="millihex" />
 

--- a/robot/millihex_description.xacro
+++ b/robot/millihex_description.xacro
@@ -57,7 +57,7 @@
     <xacro:property name="joint_upper_limit" value="${pi / 2}" />   <!-- (rad) -->
     <xacro:property name="joint_lower_limit" value="${-pi / 2}" />  <!-- (rad) -->
     <xacro:property name="joint_effort_limit" value="0.1" />        <!-- (N*m) -->
-    <xacro:property name="joint_velocity_limit" value="${pi / 4}" />      <!-- (rad/s) -->
+    <xacro:property name="joint_velocity_limit" value="0.1" />      <!-- (rad/s) -->
     
     <!-- Thorax Leg Joint Attachment Positions -->
     <xacro:property name="leg_spacing" value="${(2 * coxa_x) + leg_link_2_x}" />

--- a/robot/millihex_description.xacro
+++ b/robot/millihex_description.xacro
@@ -350,7 +350,7 @@
                    upper="${joint_upper_limit}"
                    effort="${joint_effort_limit}"
                    velocity="${joint_velocity_limit}" />
-            <axis xyz="1 0 0" />
+            <axis xyz="-1 0 0" />
         </joint>
         <xacro:leg_transmission leg_number="${leg_number}" joint_number="1" />
 
@@ -377,7 +377,7 @@
                    upper="${joint_upper_limit}"
                    effort="${joint_effort_limit}"
                    velocity="${joint_velocity_limit}" />
-            <axis xyz="0 1 0" />
+            <axis xyz="0 -1 0" />
         </joint>
         <xacro:leg_transmission leg_number="${leg_number}" joint_number="2" />
 
@@ -397,13 +397,14 @@
         <joint name="leg${leg_number}_joint3" type="revolute">
             <parent link="leg${leg_number}_link2" />
             <child link="leg${leg_number}_joint_link3" />
-            <origin xyz="${-(leg_link_2_x / 2) + (joint_link_l / 2)} ${(leg_link_2_y / 2) + (joint_link_r)} 0" rpy="0 0 0" />
+            <origin xyz="${-(leg_link_2_x / 2) + (joint_link_l / 2)}
+                ${(leg_link_2_y / 2) + (joint_link_r)} 0" rpy="0 0 0" />
             <dynamics damping="${joint_damping}" friction="${joint_friction}" />
             <limit lower="${joint_lower_limit}"
                    upper="${joint_upper_limit}"
                    effort="${joint_effort_limit}"
                    velocity="${joint_velocity_limit}" />
-            <axis xyz="1 0 0" />
+            <axis xyz="-1 0 0" />
         </joint>
         <xacro:leg_transmission leg_number="${leg_number}" joint_number="3" />
 

--- a/robot/millihex_description.xacro
+++ b/robot/millihex_description.xacro
@@ -1,35 +1,25 @@
+<?xml version="1.0"?>
 <!-- Check URDF: -->
 <!-- rosrun xacro xacro millihex_description.xacro > millihex_description.urdf -->
 
-<?xml version="1.0"?>
 <robot name="millihex" xmlns:xacro="http://www.ros.org/wiki/xacro">
-
-    <!-- Equations -->
-    <!-- Calculate Mass of a Box -->
-    <xacro:macro name="box_mass" params="density x y z">
-        <mass value="${density*x*y*z}" />
-    </xacro:macro>
-
-    <!-- Calculate Moment of Inertia of a Box -->
-    <xacro:macro name="box_inertia" params="mass x y z">
-        <inertia ixx="${mass*(y*y+z*z)/12}" ixy = "0" ixz = "0"
-            iyy="${mass*(x*x+z*z)/12}" iyz = "0" izz="${mass*(x*x+y*y)/12}" />
-    </xacro:macro>
-
-
     <!-- Physical Properties -->
-    <!-- PCB density ~ FR4 density (kg/m^3) -->
+    <!-- PCB density ~= FR4 density (kg/m^3) -->
+    <!-- PCB thickness (m) -->
     <xacro:property name="pcb_density" value="1850" />
+    <xacro:property name="pcb_thickness_z" value="0.0015" />
 
-    <!-- Torso mass (kg) and x,y dimensions (m) -->
-    <xacro:property name="torso_mass" value="0.01" />
+    <!-- Torso x,y dimensions (m) and mass (kg) -->
     <xacro:property name="torso_x" value="0.14" />
     <xacro:property name="torso_y" value="0.04" />
+    <xacro:property name="torso_mass"
+        value="${pcb_density * torso_x * torso_y * pcb_thickness_z}" />
 
-    <!-- Leg mass (kg) and x,y dimensions (m) -->
-    <xacro:property name="leg_link_mass" value="0.0008" />
+    <!-- Leg x,y dimensions (m) -->
     <xacro:property name="leg_link_x" value="0.02" />
     <xacro:property name="leg_link_y" value="0.03" />
+    <xacro:property name="leg_link_mass"
+        value="${pcb_density * leg_link_x * leg_link_y * pcb_thickness_z}" />
 
     <!-- Joint limits (rad) -->
     <xacro:property name="joint_upper_limit" value="1.5708" />
@@ -37,16 +27,13 @@
     <xacro:property name="joint_effort_limit" value="0.01" />
     <xacro:property name="joint_velocity_limit" value="0.01" />
 
-    <!-- Joint damping (b = N*s/m) and spring constant (k = N/m) -->
+    <!-- Joint damping (N*m*s/rad) and friction (N*m) -->
     <xacro:property name="joint_damping" value="0.00003" />
     <xacro:property name="joint_friction" value="0.001" />
 
-    <!-- PCB thickness (m) -->
-    <xacro:property name="pcb_thickness_z" value="0.0005" />
-
-    <!-- Link Gazebo properties -->
-    <!-- Contact stiffness (kp) -->
-    <!-- Contact damping (kp) -->
+    <!-- Gazebo Properties -->
+    <!-- Link contact stiffness (kp) -->
+    <!-- Link contact damping (kp) -->
     <xacro:property name="link_kp" value="1000.0" />
     <xacro:property name="link_kd" value="1000.0" />
 
@@ -63,6 +50,14 @@
     <material name="Orange">
         <color rgba="0.98 0.41 0.055 1" />
     </material>
+
+
+    <!-- Equation Macros -->
+    <!-- Calculate Moment of Inertia of a Box -->
+    <xacro:macro name="box_inertia" params="mass x y z">
+        <inertia ixx="${mass*(y*y+z*z)/12}" ixy = "0" ixz = "0"
+            iyy="${mass*(x*x+z*z)/12}" iyz = "0" izz="${mass*(x*x+y*y)/12}" />
+    </xacro:macro>
 
 
     <!-- Base and Torso Definition -->

--- a/robot/millihex_description.xacro
+++ b/robot/millihex_description.xacro
@@ -72,8 +72,8 @@
     <xacro:property name="frontal_leg_x" value="${(thorax_x / 2) - (coxa_x / 2)}" />
     <xacro:property name="medial_leg_x" value="${frontal_leg_x - leg_spacing}" />
     <xacro:property name="hind_leg_x" value="${medial_leg_x - leg_spacing}" />
-    <xacro:property name="right_side_y" value="${thorax_y / 2}" />
-    <xacro:property name="left_side_y" value="${-(thorax_y / 2)}" />
+    <xacro:property name="right_side_y" value="${(thorax_y / 2) + (coxa_y / 2)}" />
+    <xacro:property name="left_side_y" value="${-((thorax_y / 2) + (coxa_y / 2))}" />
         
     <!-- Joint Link Properties -->
     <xacro:property name="joint_link_r" value="0.0015" />  <!-- radius (m) -->
@@ -88,14 +88,14 @@
     <xacro:property name="joint_friction" value="0.0" />         <!-- friction (N*m) -->
 
     <!-- Color Definitions -->
-    <material name="Cyan">
-        <color rgba="0.0 1.0 1.0 1.0" />
-    </material>
     <material name="Black">
         <color rgba="0.0 0.0 0.0 1.0" />
     </material>
     <material name="Orange">
         <color rgba="0.98 0.41 0.055 1.0" />
+    </material>
+    <material name="White">
+        <color rgba="0.0 0.0 0.0 0.0" />
     </material>
 
     <!-- Calculate Moment of Inertia of a Box -->
@@ -219,7 +219,8 @@
     </xacro:macro>
 
     <!-- Joint Link Definition -->
-    <xacro:macro name="millihex_joint_link" params="leg_number link_number color">
+    <xacro:macro name="millihex_joint_link"
+        params="leg_number link_number yaw color">
         <!-- Joint Link Geometry -->
         <link name="leg${leg_number}_joint_link${link_number}">
             <collision>
@@ -229,7 +230,7 @@
                 </geometry>
             </collision>
             <visual>
-                <origin xyz="0 0 0" rpy="0 0 0" />
+                <origin xyz="0 0 0" rpy="0 ${pi / 2} ${yaw}" />
                 <geometry>
                     <cylinder radius="${joint_link_r}" length="${joint_link_l}" />
                 </geometry>
@@ -267,11 +268,13 @@
         <xacro:millihex_coxa leg_number="${leg_number}" color="Black" />
 
         <!-- Coxa to Femur Joint Link (Joint Link 1) -->
-        <xacro:millihex_joint_link leg_number="${leg_number}" link_number="1" color="Cyan" />
+        <xacro:millihex_joint_link leg_number="${leg_number}" link_number="1"
+            yaw="0.0" color="White" />
         <!-- leg#_joint1 -->
         <joint name="leg${leg_number}_joint1" type="revolute">
             <parent link="leg${leg_number}_coxa" />
             <child link="leg${leg_number}_joint_link1" />
+            <origin xyz="0 ${(coxa_y / 2) + (joint_link_r)} 0" rpy="0 0 0" />
             <dynamics damping="${joint_damping}" friction="${joint_friction}" />
             <limit lower="${joint_lower_limit}"
                    upper="${joint_upper_limit}"
@@ -287,7 +290,7 @@
         <joint name="leg${leg_number}_fixed_joint1" type="fixed">
             <parent link="leg${leg_number}_joint_link1" />
             <child link="leg${leg_number}_link1" />
-            <origin xyz="0 0 0" rpy="0 0 0" />
+            <origin xyz="0 ${(leg_link_1_y / 2) + (joint_link_r)} 0" rpy="0 0 0" />
         </joint>
     </xacro:macro>
 

--- a/robot/millihex_description.xacro
+++ b/robot/millihex_description.xacro
@@ -15,7 +15,7 @@
 
     <!-- PCB Properties -->
     <xacro:property name="pcb_density" value="1850" />       <!-- FR4 density (kg/m^3) -->
-    <xacro:property name="pcb_thickness_z" value="0.003" />  <!-- PCB thickness (m) -->
+    <xacro:property name="pcb_thickness_z" value="0.002" />  <!-- PCB thickness (m) -->
 
     <!-- Thorax Properties -->
     <xacro:property name="thorax_x" value="0.25" />     <!-- x length (m) -->
@@ -48,8 +48,8 @@
         value="${pcb_density * (leg_link_3_x * leg_link_3_y * pcb_thickness_z)}" />  <!-- (kg) -->
         
     <!-- Joint Link Properties -->
-    <xacro:property name="joint_link_r" value="0.0015" />  <!-- radius (m) -->
-    <xacro:property name="joint_link_l" value="0.01" />    <!-- length (m) -->
+    <xacro:property name="joint_link_r" value="${pcb_thickness_z / 2}" />  <!-- radius (m) -->
+    <xacro:property name="joint_link_l" value="${coxa_x}" />               <!-- length (m) -->
     <xacro:property name="joint_link_mass"
         value="${pcb_density * (pi * (joint_link_r * joint_link_r) * joint_link_l)}" />  <!-- (kg) -->
 

--- a/robot/millihex_description.xacro
+++ b/robot/millihex_description.xacro
@@ -1,60 +1,86 @@
 <?xml version="1.0"?>
-<!-- Check URDF: -->
+
+<!-- Generate URDF: -->
 <!-- rosrun xacro xacro millihex_description.xacro > millihex_description.urdf -->
 
 <robot name="millihex" xmlns:xacro="http://www.ros.org/wiki/xacro">
-    <!-- Physical Properties -->
-    <!-- PCB density ~= FR4 density (kg/m^3) -->
-    <!-- PCB thickness (m) -->
-    <xacro:property name="pcb_density" value="1850" />
-    <xacro:property name="pcb_thickness_z" value="0.003" />
 
-    <!-- Torso Link x,y dimensions (m) and mass (kg) -->
-    <xacro:property name="torso_x" value="0.14" />
-    <xacro:property name="torso_y" value="0.04" />
-    <xacro:property name="torso_mass"
-        value="${pcb_density * torso_x * torso_y * pcb_thickness_z}" />
+    <!-- PCB Properties -->
+    <xacro:property name="pcb_density" value="1850" />       <!-- FR4 density (kg/m^3) -->
+    <xacro:property name="pcb_thickness_z" value="0.003" />  <!-- PCB thickness (m) -->
 
-    <!-- Leg Link x,y dimensions (m) and mass (kg) -->
-    <xacro:property name="leg_link_x" value="0.02" />
-    <xacro:property name="leg_link_y" value="0.03" />
-    <xacro:property name="leg_link_mass"
-        value="${pcb_density * leg_link_x * leg_link_y * pcb_thickness_z}" />
+    <!-- Thorax Properties -->
+    <xacro:property name="thorax_x" value="0.20" />     <!-- x length (m) -->
+    <xacro:property name="thorax_y" value="0.03" />     <!-- y length (m) -->
+    <xacro:property name="thorax_kp" value="1000.0" />  <!-- contact stiffness -->
+    <xacro:property name="thorax_kd" value="1000.0" />  <!-- contact damping -->
+    <xacro:property name="thorax_mu1" value="10.0" />   <!-- friction coef 1 -->
+    <xacro:property name="thorax_mu2" value="10.0" />   <!-- friction coef 2 -->
+    <xacro:property name="thorax_mass"
+        value="${pcb_density * (thorax_x * thorax_y * pcb_thickness_z)}" />  <!-- (kg) -->
+    
+    <!-- Coxa Properties -->
+    <xacro:property name="coxa_x" value="0.14" />     <!-- x length (m) -->
+    <xacro:property name="coxa_y" value="0.04" />     <!-- y length (m) -->
+    <xacro:property name="coxa_kp" value="1000.0" />  <!-- contact stiffness -->
+    <xacro:property name="coxa_kd" value="1000.0" />  <!-- contact damping -->
+    <xacro:property name="coxa_mu1" value="10.0" />   <!-- friction coef 1 -->
+    <xacro:property name="coxa_mu2" value="10.0" />   <!-- friction coef 2 -->
+    <xacro:property name="coxa_mass"
+        value="${pcb_density * (coxa_x * coxa_y * pcb_thickness_z)}" />  <!-- (kg) -->
 
-    <!-- Fake Joint Link r,l dimensions (m) -->
-    <xacro:property name="fake_joint_link_r" value="${pcb_thickness_z / 2}" />
-    <xacro:property name="fake_joint_link_l" value="${leg_link_x}" />
+    <!-- Femur (Leg Link 1) Properties -->
+    <xacro:property name="leg_link_1_x" value="0.02" />     <!-- x length (m) -->
+    <xacro:property name="leg_link_1_y" value="0.03" />     <!-- y length (m) -->
+    <xacro:property name="leg_link_1_kp" value="1000.0" />  <!-- contact stiffness -->
+    <xacro:property name="leg_link_1_kd" value="1000.0" />  <!-- contact damping -->
+    <xacro:property name="leg_link_1_mu1" value="10.0" />   <!-- friction coef 1 -->
+    <xacro:property name="leg_link_1_mu2" value="10.0" />   <!-- friction coef 2 -->
+    <xacro:property name="leg_link_1_mass"
+        value="${pcb_density * (leg_link_1_x * leg_link_2_y * pcb_thickness_z)}" />  <!-- (kg) -->
 
-    <!-- Joint limits (rad) -->
-    <xacro:property name="joint_upper_limit" value="1.5708" />
-    <xacro:property name="joint_lower_limit" value="-1.5708" />
-    <xacro:property name="joint_effort_limit" value="0.01" />
-    <xacro:property name="joint_velocity_limit" value="0.01" />
+    <!-- Tibia (Leg Link 2) Properties -->
+    <xacro:property name="leg_link_2_x" value="0.02" />     <!-- x length (m) -->
+    <xacro:property name="leg_link_2_y" value="0.03" />     <!-- y length (m) -->
+    <xacro:property name="leg_link_2_kp" value="1000.0" />  <!-- contact stiffness -->
+    <xacro:property name="leg_link_2_kd" value="1000.0" />  <!-- contact damping -->
+    <xacro:property name="leg_link_2_mu1" value="10.0" />   <!-- friction coef 1 -->
+    <xacro:property name="leg_link_2_mu2" value="10.0" />   <!-- friction coef 2 -->
+    <xacro:property name="leg_link_2_mass"
+        value="${pcb_density * (leg_link_2_x * leg_link_2_y * pcb_thickness_z)}" />  <!-- (kg) -->
 
-    <!-- Joint damping (N*m*s/rad) and friction (N*m) -->
-    <xacro:property name="joint_damping" value="0.00003" />
-    <xacro:property name="joint_friction" value="0.001" />
+    <!-- Tarsus (Leg Link 3) Properties -->
+    <xacro:property name="leg_link_3_x" value="0.02" />     <!-- x length (m) -->
+    <xacro:property name="leg_link_3_y" value="0.03" />     <!-- y length (m) -->
+    <xacro:property name="leg_link_3_kp" value="1000.0" />  <!-- contact stiffness -->
+    <xacro:property name="leg_link_3_kd" value="1000.0" />  <!-- contact damping -->
+    <xacro:property name="leg_link_3_mu1" value="10.0" />   <!-- friction coef 1 -->
+    <xacro:property name="leg_link_3_mu2" value="10.0" />   <!-- friction coef 2 -->
+    <xacro:property name="leg_link_3_mass"
+        value="${pcb_density * (leg_link_3_x * leg_link_3_y * pcb_thickness_z)}" />  <!-- (kg) -->
+        
+    <!-- Joint Link Properties -->
+    <xacro:property name="joint_link_r" value="${pcb_thickness_z / 2}" />  <!-- radius (m) -->
+    <xacro:property name="joint_link_l" value="${leg_link_x}" />           <!-- length (m) -->
 
-    <!-- Gazebo Properties -->
-    <!-- Link contact stiffness (kp) -->
-    <!-- Link contact damping (kp) -->
-    <xacro:property name="link_kp" value="1000.0" />
-    <xacro:property name="link_kd" value="1000.0" />
-
-    <!-- Link coulomb friction coefficients in direction 1,2 -->
-    <!-- mu = [0, inf] where higher mu means less slip -->
-    <xacro:property name="link_mu1" value="10.0" />
-    <xacro:property name="link_mu2" value="10.0" />
-
+    <!-- Revolute Joint Properties -->
+    <xacro:property name="joint_upper_limit" value="1.5708" />   <!-- (rad) -->
+    <xacro:property name="joint_lower_limit" value="-1.5708" />  <!-- (rad) -->
+    <xacro:property name="joint_effort_limit" value="0.1" />     <!-- (rad/s) -->
+    <xacro:property name="joint_velocity_limit" value="0.1" />   <!-- (rad/s) -->
+    <xacro:property name="joint_damping" value="0.0" />          <!-- damping (N*m*s/rad)-->
+    <xacro:property name="joint_friction" value="0.0" />         <!-- friction (N*m) -->
 
     <!-- Color Definitions -->
+    <material name="Cyan">
+        <color rgba="0.0 1.0 1.0 1.0" />
+    </material>
     <material name="Black">
-        <color rgba="0 0 0 1" />
+        <color rgba="0.0 0.0 0.0 1.0" />
     </material>
     <material name="Orange">
-        <color rgba="0.98 0.41 0.055 1" />
+        <color rgba="0.98 0.41 0.055 1.0" />
     </material>
-
 
     <!-- Equation Macros -->
     <!-- Calculate Moment of Inertia of a Box -->
@@ -63,58 +89,56 @@
             iyy="${mass*(x*x+z*z)/12}" iyz = "0" izz="${mass*(x*x+y*y)/12}" />
     </xacro:macro>
 
-
-    <!-- Torso Definition -->
-    <xacro:macro name="millihex_torso" params="color">
+    <!-- Thorax Definition -->
+    <xacro:macro name="millihex_thorax" params="color">
+    
         <!-- Dummy Base Link to support KDL -->
         <link name="base_link" />
-
-        <!-- Torso Geometry -->
-        <link name="torso">
+        
+        <!-- Thorax Geometry -->
+        <link name="thorax">
             <inertial>
                 <origin xyz="0 0 ${pcb_thickness_z / 2}" rpy="0 0 0" />
-                <mass value="${torso_mass}" />
-                <xacro:box_inertia mass="${torso_mass}" x="${torso_x}"
-                    y="${torso_y}" z="${pcb_thickness_z}" />
+                <mass value="${thorax_mass}" />
+                <xacro:box_inertia mass="${thorax_mass}" x="${thorax_x}"
+                    y="${thorax_y}" z="${pcb_thickness_z}" />
             </inertial>
             <collision>
                 <origin xyz="0 0 0" rpy="0 0 0" />
                 <geometry>
-                    <box size="${torso_x} ${torso_y} ${pcb_thickness_z}" />
+                    <box size="${thorax_x} ${thorax_y} ${pcb_thickness_z}" />
                 </geometry>
             </collision>
             <visual>
                 <origin xyz="0 0 0" rpy="0 0 0" />
                 <geometry>
-                    <box size="${torso_x} ${torso_y} ${pcb_thickness_z}" />
+                    <box size="${thorax_x} ${thorax_y} ${pcb_thickness_z}" />
                 </geometry>
                 <material name="${color}" />
             </visual>
         </link>
 
         <!-- Gazebo properties -->
-        <gazebo reference="torso">
-            <kp>${link_kp}</kp>
-            <kd>${link_kd}</kd>
-            <mu1>${link_mu1}</mu1>
-            <mu2>${link_mu2}</mu2>
+        <gazebo reference="thorax">
+            <kp>${thorax_kp}</kp>
+            <kd>${thorax_kd}</kd>
+            <mu1>${thorax_mu1}</mu1>
+            <mu2>${thorax_mu2}</mu2>
             <material>Gazebo/${color}</material>
         </gazebo>
 
-        <!-- Join Base Link and Torso -->
+        <!-- Join Base Link and Thorax -->
         <joint name="base_joint" type="fixed">
             <parent link="base_link" />
-            <child link="torso" />
+            <child link="thorax" />
         </joint>
     </xacro:macro>
 
 
-    <!-- Fake Joint Link Definition -->
-    <xacro:macro name="millihex_fake_joint_link"
-        params="leg_number link_number x_length y_length color">
-
-        <!-- Fake Joint Link Geometry -->
-        <link name="leg${leg_number}_link${link_number}">
+    <!-- Joint Link Definition -->
+    <xacro:macro name="millihex_joint_link" params="leg_number link_number color">
+        <!-- Joint Link Geometry -->
+        <link name="leg${leg_number}_joint_link${link_number}">
             <collision>
                 <origin xyz="-${x_length / 2} -${y_length / 2} 0" rpy="0 0 0" />
                 <geometry>
@@ -222,42 +246,6 @@
 
         <xacro:leg_transmission leg_number="${leg_number}" joint_number="1" />
 
-        <!-- Link 2, horizontally oriented -->
-        <xacro:millihex_leg_link leg_number="${leg_number}" link_number="2"
-            x_length="${leg_link_x}" y_length="${leg_link_y}" color="Black" />
-
-        <joint name="leg${leg_number}_joint2" type="revolute">
-            <parent link="leg${leg_number}_link1" />
-            <child link="leg${leg_number}_link2" />
-            <origin xyz="-${leg_link_y} 0 0" rpy="0 0 0" />
-            <dynamics damping="${joint_damping}" friction="${joint_friction}" />
-            <limit lower="${joint_lower_limit}"
-                   upper="${joint_upper_limit}"
-                   effort="${joint_effort_limit}"
-                   velocity="${joint_velocity_limit}" />
-            <axis xyz="0 -1 0" />
-        </joint>
-
-        <xacro:leg_transmission leg_number="${leg_number}" joint_number="2" />
-
-        <!-- Link 3, horizontally oriented -->
-        <xacro:millihex_leg_link leg_number="${leg_number}" link_number="3"
-            x_length="${leg_link_x}" y_length="${leg_link_y}" color="Orange" />
-
-        <joint name="leg${leg_number}_joint3" type="revolute">
-            <parent link="leg${leg_number}_link2" />
-            <child link="leg${leg_number}_link3" />
-            <origin xyz="0 -${leg_link_y} 0" rpy="0 0 0" />
-            <dynamics damping="${joint_damping}" friction="${joint_friction}" />
-            <limit lower="${joint_lower_limit}"
-                   upper="${joint_upper_limit}"
-                   effort="${joint_effort_limit}"
-                   velocity="${joint_velocity_limit}" />
-            <axis xyz="1 0 0" />
-        </joint>
-
-        <xacro:leg_transmission leg_number="${leg_number}" joint_number="3" />
-
     </xacro:macro>
 
 
@@ -273,53 +261,6 @@
             <parent link="torso" />
             <child link="leg1_link0" />
             <origin xyz="${torso_x / 2} -${torso_y / 2} 0" rpy="0 0 0" />
-        </joint>
-
-        <!-- Leg 2 -->
-        <xacro:millihex_leg leg_number="2" />
-        <!-- Leg 2, Joint 0 (fixed, shoulder joint) -->
-        <joint name="leg2_joint0" type="fixed">
-            <parent link="torso" />
-            <child link="leg2_link0" />
-            <origin xyz="${leg_link_x / 2} -${torso_y / 2} 0" rpy="0 0 0" />
-        </joint>
-
-        <!-- Leg 3 -->
-        <xacro:millihex_leg leg_number="3" />
-        <!-- Leg 3, Joint 0 (fixed, shoulder joint) -->
-        <joint name="leg3_joint0" type="fixed">
-            <parent link="torso" />
-            <child link="leg3_link0" />
-            <origin xyz="-${torso_x / 2 - leg_link_x} -${torso_y / 2} 0"
-                rpy="0 0 0" />
-        </joint>
-
-        <!-- Leg 4 -->
-        <xacro:millihex_leg leg_number="4" />
-        <!-- Leg 4, Joint 0 (fixed, shoulder joint) -->
-        <joint name="leg4_joint0" type="fixed">
-            <parent link="torso" />
-            <child link="leg4_link0" />
-            <origin xyz="${torso_x / 2} ${torso_y / 2} 0" rpy="3.1416 0 0" />
-        </joint>
-
-        <!-- Leg 5 -->
-        <xacro:millihex_leg leg_number="5" />
-        <!-- Leg 5, Joint 0 (fixed, shoulder joint) -->
-        <joint name="leg5_joint0" type="fixed">
-            <parent link="torso" />
-            <child link="leg5_link0" />
-            <origin xyz="${leg_link_x / 2} ${torso_y / 2} 0" rpy="3.1416 0 0" />
-        </joint>
-
-        <!-- Leg 6 -->
-        <xacro:millihex_leg leg_number="6" />
-        <!-- Leg 6, Joint 0 (fixed, shoulder joint) -->
-        <joint name="leg6_joint0" type="fixed">
-            <parent link="torso" />
-            <child link="leg6_link0" />
-            <origin xyz="-${torso_x / 2 - leg_link_x} ${torso_y / 2} 0"
-                rpy="3.1416 0 0" />
         </joint>
     
     </xacro:macro>

--- a/robot/millihex_description.xacro
+++ b/robot/millihex_description.xacro
@@ -84,18 +84,18 @@
         <color rgba="0.0 0.0 0.0 0.0" />
     </material>
 
-    <!-- Calculate Moment of Inertia of a Box -->
+    <!-- Calculate Inertia Tensor of a Box -->
     <xacro:macro name="box_inertia" params="mass x y z">
         <inertia ixx="${(1 / 12) * mass * ((y * y) + (z * z))}" ixy = "0" ixz = "0"
                  iyy="${(1 / 12) * mass * ((x * x) + (z * z))}" iyz = "0"
                  izz="${(1 / 12) * mass * ((x * x) + (y * y))}" />
     </xacro:macro>
 
-    <!-- Calculate Moment of Inertia of a Cylinder -->
+    <!-- Calculate Inertia Tensor of a Cylinder -->
     <xacro:macro name="cylinder_inerta" params="mass r l">
-        <inertia ixx="${(1 / 12) * mass * (l * l)}" ixy = "0" ixz = "0"
-                 iyy="${(1 / 12) * mass * (l * l)}" iyz = "0"
-                 izz="${(1 / 2) * mass * (r * r)}" />
+        <inertia ixx="${(1 / 12) * mass * (3 * (r * r) + (l * l))}" ixy = "0" ixz = "0"
+                 iyy="${(1 / 12) * mass * (3 * (r * r) + (l * l))}" iyz = "0"
+                 izz="${(1 / 12) * mass * (r * r)}" />
     </xacro:macro>
 
     <!-- Thorax Definition -->

--- a/src/demo.py
+++ b/src/demo.py
@@ -29,19 +29,26 @@ def main():
         print(f"swing_state: {millihex.get_swing_state()}\n")
         rate.sleep()
 
-        # millihex.set_joint_position(1, 1, -np.pi / 4)
+        millihex.set_joint_position(1, 1, -np.pi/4)
 
-        millihex.stand_up()
-        print(f"stance_state: {millihex.get_stance_state()}")
-        print(f"swing_state: {millihex.get_swing_state()}\n")
-        rate.sleep()
+        # x = 0.0
+        # rate = rospy.Rate(5)
+        # while (True):
+        #     millihex.set_joint_position(1, 1, -np.sin(x * 2 / np.pi))
+        #     rate.sleep()
+        #     x = x + 0.05
 
-        # Test millihex tripod gait
-        while not rospy.is_shutdown():
-            millihex.tripod_gait()
-            print(f"stance_state: {millihex.get_stance_state()}")
-            print(f"swing_state: {millihex.get_swing_state()}\n")
-            rate.sleep()
+        # millihex.stand_up()
+        # print(f"stance_state: {millihex.get_stance_state()}")
+        # print(f"swing_state: {millihex.get_swing_state()}\n")
+        # rate.sleep()
+
+        # # Test millihex tripod gait
+        # while not rospy.is_shutdown():
+        #     millihex.tripod_gait()
+        #     print(f"stance_state: {millihex.get_stance_state()}")
+        #     print(f"swing_state: {millihex.get_swing_state()}\n")
+        #     rate.sleep()
 
     except rospy.ROSInterruptException:
         pass

--- a/src/demo.py
+++ b/src/demo.py
@@ -29,7 +29,7 @@ def main():
         print(f"swing_state: {millihex.get_swing_state()}\n")
         rate.sleep()
 
-        millihex.set_joint_position(1, 1, -np.pi/4)
+        # millihex.set_joint_position(1, 1, -np.pi/4)
 
         # x = 0.0
         # rate = rospy.Rate(5)
@@ -38,10 +38,10 @@ def main():
         #     rate.sleep()
         #     x = x + 0.05
 
-        # millihex.stand_up()
-        # print(f"stance_state: {millihex.get_stance_state()}")
-        # print(f"swing_state: {millihex.get_swing_state()}\n")
-        # rate.sleep()
+        millihex.stand_up()
+        print(f"stance_state: {millihex.get_stance_state()}")
+        print(f"swing_state: {millihex.get_swing_state()}\n")
+        rate.sleep()
 
         # # Test millihex tripod gait
         # while not rospy.is_shutdown():

--- a/src/demo.py
+++ b/src/demo.py
@@ -7,7 +7,7 @@ from millihex_robot import Robot
 def main():
     """Initializes ROS node for robot"""
     try:
-        rospy.init_node('robot_rock', anonymous=True)       # Initialize ROS node
+        rospy.init_node('robot_walk', anonymous=True)       # Initialize ROS node
         rate = rospy.Rate(0.5)        # Set refresh rate
 
         # Initialize a Robot object to spawn millihex
@@ -15,51 +15,48 @@ def main():
         joints_per_leg = 3
         millihex = Robot(num_legs, joints_per_leg)
 
+        # Confirm that all publishers connected
         print("ROBOT INITIALIZED")
         print(f"Joint Position Publisher connections = {millihex.num_joint_publishers}\n")
 
+        # Wait for rosnode to connect to subscriber
         print("Waiting for Joint States Subscriber...")
         while millihex.subscriber.get_num_connections() < 1:
             rate.sleep()
 
         print(f"Joint States Subscriber connections = {millihex.subscriber.get_num_connections()}\n")
         
+        # Reset millihex to lying down
         millihex.lay_down()
         print(f"stance_state: {millihex.get_stance_state()}")
         print(f"swing_state: {millihex.get_swing_state()}\n")
         rate.sleep()
 
-        # for i in range((int) (num_legs / 2)):
-        #     millihex.set_joint_position(i+1, 1, -np.pi/4)
-        #     millihex.set_joint_position(i+1+3, 1, np.pi/4)
-
-        # rate.sleep()
-        # millihex.set_joint_position(1, 1, 0)
-        # rate.sleep()
-        # millihex.set_joint_position(1, 1, np.pi/4)
-        # rate.sleep()
-        # millihex.set_joint_position(1, 1, 0)
-        # rate.sleep()
-        # millihex.set_joint_position(1, 1, -np.pi/4)
-
-        # x = 0.0
-        # rate = rospy.Rate(5)
-        # while (True):
-        #     millihex.set_joint_position(1, 1, -np.sin(x * 2 / np.pi))
-        #     rate.sleep()
-        #     x = x + 0.05
-
+        # # Test millihex stand up
         # millihex.stand_up()
         # print(f"stance_state: {millihex.get_stance_state()}")
         # print(f"swing_state: {millihex.get_swing_state()}\n")
         # rate.sleep()
 
-        # Test millihex tripod gait
-        while not rospy.is_shutdown():
-            millihex.tripod_gait()
-            print(f"stance_state: {millihex.get_stance_state()}")
-            print(f"swing_state: {millihex.get_swing_state()}\n")
-            rate.sleep()
+        # Test joint movement at 100 Hz
+        x = 0.0
+        angle_rate = rospy.Rate(100)
+        while (True):
+            for i in range((int) (num_legs / 2)):
+                i = i + 1
+                angle = np.sin(x) * (3.0/4.0 * np.pi / 2)
+                print(f"angle = {angle}")
+                millihex.set_joint_position(i, 1, -angle)
+                millihex.set_joint_position(i + 3, 1, angle)
+                angle_rate.sleep()
+                x = x + 0.005
+
+        # # Test millihex tripod gait
+        # while not rospy.is_shutdown():
+        #     millihex.tripod_gait()
+        #     print(f"stance_state: {millihex.get_stance_state()}")
+        #     print(f"swing_state: {millihex.get_swing_state()}\n")
+        #     rate.sleep()
 
     except rospy.ROSInterruptException:
         pass

--- a/src/demo.py
+++ b/src/demo.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import sys
 import rospy
+import numpy as np
 from millihex_robot import Robot
 
 def main():
@@ -28,17 +29,19 @@ def main():
         print(f"swing_state: {millihex.get_swing_state()}\n")
         rate.sleep()
 
+        # millihex.set_joint_position(1, 1, -np.pi / 4)
+
         millihex.stand_up()
         print(f"stance_state: {millihex.get_stance_state()}")
         print(f"swing_state: {millihex.get_swing_state()}\n")
         rate.sleep()
 
-        # Test millihex tripod gait
-        while not rospy.is_shutdown():
-            millihex.tripod_gait()
-            print(f"stance_state: {millihex.get_stance_state()}")
-            print(f"swing_state: {millihex.get_swing_state()}\n")
-            rate.sleep()
+        # # Test millihex tripod gait
+        # while not rospy.is_shutdown():
+        #     millihex.tripod_gait()
+        #     print(f"stance_state: {millihex.get_stance_state()}")
+        #     print(f"swing_state: {millihex.get_swing_state()}\n")
+        #     rate.sleep()
 
     except rospy.ROSInterruptException:
         pass

--- a/src/demo.py
+++ b/src/demo.py
@@ -36,12 +36,12 @@ def main():
         print(f"swing_state: {millihex.get_swing_state()}\n")
         rate.sleep()
 
-        # # Test millihex tripod gait
-        # while not rospy.is_shutdown():
-        #     millihex.tripod_gait()
-        #     print(f"stance_state: {millihex.get_stance_state()}")
-        #     print(f"swing_state: {millihex.get_swing_state()}\n")
-        #     rate.sleep()
+        # Test millihex tripod gait
+        while not rospy.is_shutdown():
+            millihex.tripod_gait()
+            print(f"stance_state: {millihex.get_stance_state()}")
+            print(f"swing_state: {millihex.get_swing_state()}\n")
+            rate.sleep()
 
     except rospy.ROSInterruptException:
         pass

--- a/src/demo.py
+++ b/src/demo.py
@@ -29,6 +29,17 @@ def main():
         print(f"swing_state: {millihex.get_swing_state()}\n")
         rate.sleep()
 
+        # for i in range((int) (num_legs / 2)):
+        #     millihex.set_joint_position(i+1, 1, -np.pi/4)
+        #     millihex.set_joint_position(i+1+3, 1, np.pi/4)
+
+        # rate.sleep()
+        # millihex.set_joint_position(1, 1, 0)
+        # rate.sleep()
+        # millihex.set_joint_position(1, 1, np.pi/4)
+        # rate.sleep()
+        # millihex.set_joint_position(1, 1, 0)
+        # rate.sleep()
         # millihex.set_joint_position(1, 1, -np.pi/4)
 
         # x = 0.0
@@ -38,17 +49,17 @@ def main():
         #     rate.sleep()
         #     x = x + 0.05
 
-        millihex.stand_up()
-        print(f"stance_state: {millihex.get_stance_state()}")
-        print(f"swing_state: {millihex.get_swing_state()}\n")
-        rate.sleep()
+        # millihex.stand_up()
+        # print(f"stance_state: {millihex.get_stance_state()}")
+        # print(f"swing_state: {millihex.get_swing_state()}\n")
+        # rate.sleep()
 
-        # # Test millihex tripod gait
-        # while not rospy.is_shutdown():
-        #     millihex.tripod_gait()
-        #     print(f"stance_state: {millihex.get_stance_state()}")
-        #     print(f"swing_state: {millihex.get_swing_state()}\n")
-        #     rate.sleep()
+        # Test millihex tripod gait
+        while not rospy.is_shutdown():
+            millihex.tripod_gait()
+            print(f"stance_state: {millihex.get_stance_state()}")
+            print(f"swing_state: {millihex.get_swing_state()}\n")
+            rate.sleep()
 
     except rospy.ROSInterruptException:
         pass

--- a/src/millihex_robot.py
+++ b/src/millihex_robot.py
@@ -115,9 +115,9 @@ class Robot:
         High stance: stance = 1"""
         for leg_number in legs:
             if stance == 0:         # Set joint angle for low stance
-                joint_angle = 0.4
+                joint_angle = 0.2
             elif stance == 1:       # Set joint angle for high stance
-                joint_angle = 0.8
+                joint_angle = 0.4
             else:                   # Stance = -1, set leg to lie down
                 joint_angle = 0.0
                 self.set_joint_position(leg_number, 2, joint_angle)
@@ -139,7 +139,7 @@ class Robot:
         Swing forward: swing = 1"""
         for leg_number in legs:
             if swing == 1:          # Set joint angle to forward swing
-                joint_angle = 1.0
+                joint_angle = 0.4
             else:                   # Swing = 0, set to neutral swing
                 joint_angle = 0.0
 

--- a/src/millihex_robot.py
+++ b/src/millihex_robot.py
@@ -28,7 +28,7 @@ class Robot:
 
                     # Initialize publisher command
                     start_publisher_command = f"self.{publisher_name} = " \
-                        f"rospy.Publisher('{publisher_topic}', Float64, queue_size=1, latch=True)"
+                        f"rospy.Publisher('{publisher_topic}', Float64, queue_size=10, latch=True)"
 
                     # Execute command string as a function
                     exec(start_publisher_command)
@@ -117,7 +117,7 @@ class Robot:
             if stance == 0:         # Set joint angle for low stance
                 joint_angle = 0.2
             elif stance == 1:       # Set joint angle for high stance
-                joint_angle = 0.4
+                joint_angle = 0.6
             else:                   # Stance = -1, set leg to lie down
                 joint_angle = 0.0
                 self.set_joint_position(leg_number, 2, joint_angle)
@@ -139,7 +139,7 @@ class Robot:
         Swing forward: swing = 1"""
         for leg_number in legs:
             if swing == 1:          # Set joint angle to forward swing
-                joint_angle = 0.4
+                joint_angle = 0.6
             else:                   # Swing = 0, set to neutral swing
                 joint_angle = 0.0
 


### PR DESCRIPTION
Updating the XACRO to scale up the size of the robot such that its inertial values are not so close to 0. The [documentation for URDF Models](http://wiki.ros.org/urdf/Tutorials/Adding%20Physical%20and%20Collision%20Properties%20to%20a%20URDF%20Model) states that

> When using realtime controllers, inertia elements of zero (or almost zero) can cause the robot model to collapse without warning, and all links will appear with their origins coinciding with the world origin.

Furthermore, it is recommended that

>  If unsure what to put, a matrix with ixx/iyy/izz=1e-3 or smaller is often a reasonable default for a mid-sized link (it corresponds to a box of 0.1 m side length with a mass of 0.6 kg).

For this millihex robot, a matrix in the range ixx/iyy/izz=(1e-3, 1e-4) should suffice.