### PR TITLE
Fake joints

### DIFF
--- a/robot/millihex_description.xacro
+++ b/robot/millihex_description.xacro
@@ -21,9 +21,9 @@
     <xacro:property name="leg_link_mass"
         value="${pcb_density * leg_link_x * leg_link_y * pcb_thickness_z}" />
 
-    <!-- Massless Joint Link x,y dimensions (m) -->
-    <xacro:property name="joint_link_r" value="${pcb_thickness_z / 2}" />
-    <xacro:property name="joint_link_l" value="${leg_link_x}"
+    <!-- Fake Joint Link r,l dimensions (m) -->
+    <xacro:property name="fake_joint_link_r" value="${pcb_thickness_z / 2}" />
+    <xacro:property name="fake_joint_link_l" value="${leg_link_x}" />
 
     <!-- Joint limits (rad) -->
     <xacro:property name="joint_upper_limit" value="1.5708" />
@@ -64,12 +64,12 @@
     </xacro:macro>
 
 
-    <!-- Base and Torso Definition -->
+    <!-- Torso Definition -->
     <xacro:macro name="millihex_torso" params="color">
-        <!-- Dummy link to support KDL -->
+        <!-- Dummy Base Link to support KDL -->
         <link name="base_link" />
 
-        <!-- Torso geometry without legs -->
+        <!-- Torso Geometry -->
         <link name="torso">
             <inertial>
                 <origin xyz="0 0 ${pcb_thickness_z / 2}" rpy="0 0 0" />
@@ -109,10 +109,43 @@
     </xacro:macro>
 
 
+    <!-- Fake Joint Link Definition -->
+    <xacro:macro name="millihex_fake_joint_link"
+        params="leg_number link_number x_length y_length color">
+
+        <!-- Fake Joint Link Geometry -->
+        <link name="leg${leg_number}_link${link_number}">
+            <collision>
+                <origin xyz="-${x_length / 2} -${y_length / 2} 0" rpy="0 0 0" />
+                <geometry>
+                    <cylinder radius="${fake_joint_link_r}"
+                        length="${fake_joint_link_l}" />
+                </geometry>
+            </collision>
+            <visual>
+                <origin xyz="-${x_length / 2} -${y_length / 2} 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="${x_length} ${y_length} ${pcb_thickness_z}" />
+                </geometry>
+                <material name="${color}"/>
+            </visual>
+        </link>
+
+        <!-- Gazebo properties -->
+        <gazebo reference="leg${leg_number}_link${link_number}">
+            <kp>${link_kp}</kp>
+            <kd>${link_kd}</kd>
+            <mu1>${link_mu1}</mu1>
+            <mu2>${link_mu2}</mu2>
+            <material>Gazebo/${color}</material>
+        </gazebo>
+    </xacro:macro>
+
+
     <!-- Leg Link Definition -->
     <xacro:macro name="millihex_leg_link"
         params="leg_number link_number x_length y_length color">
-        <!-- Leg geometry -->
+        <!-- Leg Link Geometry -->
         <link name="leg${leg_number}_link${link_number}">
             <inertial>
                 <origin xyz="0 0 ${pcb_thickness_z / 2}" rpy="0 0 0" />

--- a/robot/millihex_description.xacro
+++ b/robot/millihex_description.xacro
@@ -18,8 +18,8 @@
     <xacro:property name="pcb_thickness_z" value="0.003" />  <!-- PCB thickness (m) -->
 
     <!-- Thorax Properties -->
-    <xacro:property name="thorax_x" value="0.20" />     <!-- x length (m) -->
-    <xacro:property name="thorax_y" value="0.03" />     <!-- y length (m) -->
+    <xacro:property name="thorax_x" value="0.25" />     <!-- x length (m) -->
+    <xacro:property name="thorax_y" value="0.02" />     <!-- y length (m) -->
     <xacro:property name="thorax_kp" value="1000.0" />  <!-- contact stiffness -->
     <xacro:property name="thorax_kd" value="1000.0" />  <!-- contact damping -->
     <xacro:property name="thorax_mu1" value="10.0" />   <!-- friction coef 1 -->
@@ -80,12 +80,12 @@
     <xacro:property name="joint_link_l" value="0.01" />    <!-- length (m) -->
 
     <!-- Revolute Joint Properties -->
-    <xacro:property name="joint_upper_limit" value="1.5708" />   <!-- (rad) -->
-    <xacro:property name="joint_lower_limit" value="-1.5708" />  <!-- (rad) -->
-    <xacro:property name="joint_effort_limit" value="0.1" />     <!-- (rad/s) -->
-    <xacro:property name="joint_velocity_limit" value="0.1" />   <!-- (rad/s) -->
-    <xacro:property name="joint_damping" value="0.0" />          <!-- damping (N*m*s/rad)-->
-    <xacro:property name="joint_friction" value="0.0" />         <!-- friction (N*m) -->
+    <xacro:property name="joint_upper_limit" value="${pi / 2}" />   <!-- (rad) -->
+    <xacro:property name="joint_lower_limit" value="${-pi / 2}" />  <!-- (rad) -->
+    <xacro:property name="joint_effort_limit" value="0.1" />        <!-- (rad/s) -->
+    <xacro:property name="joint_velocity_limit" value="0.1" />      <!-- (rad/s) -->
+    <xacro:property name="joint_damping" value="0.0" />   <!-- damping (N*m*s/rad)-->
+    <xacro:property name="joint_friction" value="0.0" />  <!-- friction (N*m) -->
 
     <!-- Color Definitions -->
     <material name="Black">
@@ -218,6 +218,76 @@
         </gazebo>
     </xacro:macro>
 
+    <!-- Tibia (Leg Link 2) Definition -->
+    <xacro:macro name="millihex_leg_link_2" params="leg_number color">
+        <!-- Tibia (Leg Link 2) Geometry -->
+        <link name="leg${leg_number}_link2">
+            <inertial>
+                <origin xyz="0 0 ${pcb_thickness_z / 2}" rpy="0 0 0" />
+                <mass value="${leg_link_2_mass}" />
+                <xacro:box_inertia mass="${leg_link_2_mass}" x="${leg_link_2_x}"
+                    y="${leg_link_2_y}" z="${pcb_thickness_z}" />
+            </inertial>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="${leg_link_2_x} ${leg_link_2_y} ${pcb_thickness_z}" />
+                </geometry>
+            </collision>
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="${leg_link_2_x} ${leg_link_2_y} ${pcb_thickness_z}" />
+                </geometry>
+                <material name="${color}"/>
+            </visual>
+        </link>
+
+        <!-- Gazebo properties -->
+        <gazebo reference="leg${leg_number}_link2">
+            <kp>${leg_link_2_kp}</kp>
+            <kd>${leg_link_2_kd}</kd>
+            <mu1>${leg_link_2_mu1}</mu1>
+            <mu2>${leg_link_2_mu2}</mu2>
+            <material>Gazebo/${color}</material>
+        </gazebo>
+    </xacro:macro>
+
+    <!-- Tarsus (Leg Link 3) Definition -->
+    <xacro:macro name="millihex_leg_link_3" params="leg_number color">
+        <!-- Tarsus (Leg Link 3) Geometry -->
+        <link name="leg${leg_number}_link3">
+            <inertial>
+                <origin xyz="0 0 ${pcb_thickness_z / 2}" rpy="0 0 0" />
+                <mass value="${leg_link_3_mass}" />
+                <xacro:box_inertia mass="${leg_link_3_mass}" x="${leg_link_3_x}"
+                    y="${leg_link_3_y}" z="${pcb_thickness_z}" />
+            </inertial>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="${leg_link_3_x} ${leg_link_3_y} ${pcb_thickness_z}" />
+                </geometry>
+            </collision>
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="${leg_link_3_x} ${leg_link_3_y} ${pcb_thickness_z}" />
+                </geometry>
+                <material name="${color}"/>
+            </visual>
+        </link>
+
+        <!-- Gazebo properties -->
+        <gazebo reference="leg${leg_number}_link3">
+            <kp>${leg_link_3_kp}</kp>
+            <kd>${leg_link_3_kd}</kd>
+            <mu1>${leg_link_3_mu1}</mu1>
+            <mu2>${leg_link_3_mu2}</mu2>
+            <material>Gazebo/${color}</material>
+        </gazebo>
+    </xacro:macro>
+
     <!-- Joint Link Definition -->
     <xacro:macro name="millihex_joint_link"
         params="leg_number link_number yaw color">
@@ -292,6 +362,59 @@
             <child link="leg${leg_number}_link1" />
             <origin xyz="0 ${(leg_link_1_y / 2) + (joint_link_r)} 0" rpy="0 0 0" />
         </joint>
+
+        <!-- Femur to Tibia Joint Link (Joint Link 2) -->
+        <xacro:millihex_joint_link leg_number="${leg_number}" link_number="2"
+            yaw="${pi / 2}" color="White" />
+        <!-- leg#_joint2 -->
+        <joint name="leg${leg_number}_joint2" type="revolute">
+            <parent link="leg${leg_number}_link1" />
+            <child link="leg${leg_number}_joint_link2" />
+            <origin xyz="${-((leg_link_1_x / 2) + (joint_link_r))}
+                ${(leg_link_1_y / 2) - (joint_link_l / 2)} 0" rpy="0 0 0" />
+            <dynamics damping="${joint_damping}" friction="${joint_friction}" />
+            <limit lower="${joint_lower_limit}"
+                   upper="${joint_upper_limit}"
+                   effort="${joint_effort_limit}"
+                   velocity="${joint_velocity_limit}" />
+            <axis xyz="0 1 0" />
+        </joint>
+        <xacro:leg_transmission leg_number="${leg_number}" joint_number="2" />
+
+        <!-- Tibia (Leg Link 2) -->
+        <xacro:millihex_leg_link_2 leg_number="${leg_number}" color="Black" />
+        <!-- leg#_fixed_joint2 -->
+        <joint name="leg${leg_number}_fixed_joint2" type="fixed">
+            <parent link="leg${leg_number}_joint_link2" />
+            <child link="leg${leg_number}_link2" />
+            <origin xyz="${-((leg_link_2_x / 2) + (joint_link_r))} 0 0" rpy="0 0 0" />
+        </joint>
+
+        <!-- Tibia to Tarsus Joint Link (Joint Link 3) -->
+        <xacro:millihex_joint_link leg_number="${leg_number}" link_number="3"
+            yaw="0.0" color="White" />
+        <!-- leg#_joint3 -->
+        <joint name="leg${leg_number}_joint3" type="revolute">
+            <parent link="leg${leg_number}_link2" />
+            <child link="leg${leg_number}_joint_link3" />
+            <origin xyz="${-(leg_link_2_x / 2) + (joint_link_l / 2)} ${(leg_link_2_y / 2) + (joint_link_r)} 0" rpy="0 0 0" />
+            <dynamics damping="${joint_damping}" friction="${joint_friction}" />
+            <limit lower="${joint_lower_limit}"
+                   upper="${joint_upper_limit}"
+                   effort="${joint_effort_limit}"
+                   velocity="${joint_velocity_limit}" />
+            <axis xyz="1 0 0" />
+        </joint>
+        <xacro:leg_transmission leg_number="${leg_number}" joint_number="3" />
+
+        <!-- Tarsus (Leg Link 3) -->
+        <xacro:millihex_leg_link_3 leg_number="${leg_number}" color="Orange" />
+        <!-- leg#_fixed_joint3 -->
+        <joint name="leg${leg_number}_fixed_joint3" type="fixed">
+            <parent link="leg${leg_number}_joint_link3" />
+            <child link="leg${leg_number}_link3" />
+            <origin xyz="0 ${(leg_link_3_y / 2) + (joint_link_r)} 0" rpy="0 0 0" />
+        </joint>
     </xacro:macro>
 
     <!-- Assemble Body -->
@@ -305,6 +428,46 @@
             <parent link="thorax" />
             <child link="leg1_coxa" />
             <origin xyz="${frontal_leg_x} ${right_side_y} 0" rpy="0 0 0" />
+        </joint>
+
+        <!-- Leg 2 -->
+        <xacro:millihex_leg leg_number="2" />
+        <joint name="leg2_coxa_joint" type="fixed">
+            <parent link="thorax" />
+            <child link="leg2_coxa" />
+            <origin xyz="${medial_leg_x} ${right_side_y} 0" rpy="0 0 0" />
+        </joint>
+
+        <!-- Leg 3 -->
+        <xacro:millihex_leg leg_number="3" />
+        <joint name="leg3_coxa_joint" type="fixed">
+            <parent link="thorax" />
+            <child link="leg3_coxa" />
+            <origin xyz="${hind_leg_x} ${right_side_y} 0" rpy="0 0 0" />
+        </joint>
+
+        <!-- Leg 4 -->
+        <xacro:millihex_leg leg_number="4" />
+        <joint name="leg4_coxa_joint" type="fixed">
+            <parent link="thorax" />
+            <child link="leg4_coxa" />
+            <origin xyz="${frontal_leg_x} ${left_side_y} 0" rpy="${pi} 0 0" />
+        </joint>
+
+        <!-- Leg 5 -->
+        <xacro:millihex_leg leg_number="5" />
+        <joint name="leg5_coxa_joint" type="fixed">
+            <parent link="thorax" />
+            <child link="leg5_coxa" />
+            <origin xyz="${medial_leg_x} ${left_side_y} 0" rpy="${pi} 0 0" />
+        </joint>
+
+        <!-- Leg 6 -->
+        <xacro:millihex_leg leg_number="6" />
+        <joint name="leg6_coxa_joint" type="fixed">
+            <parent link="thorax" />
+            <child link="leg6_coxa" />
+            <origin xyz="${hind_leg_x} ${left_side_y} 0" rpy="${pi} 0 0" />
         </joint>
     </xacro:macro>
 

--- a/robot/millihex_description.xacro
+++ b/robot/millihex_description.xacro
@@ -20,8 +20,8 @@
         value="${pcb_density * (thorax_x * thorax_y * pcb_thickness_z)}" />  <!-- (kg) -->
     
     <!-- Coxa Properties -->
-    <xacro:property name="coxa_x" value="0.14" />     <!-- x length (m) -->
-    <xacro:property name="coxa_y" value="0.04" />     <!-- y length (m) -->
+    <xacro:property name="coxa_x" value="0.01" />     <!-- x length (m) -->
+    <xacro:property name="coxa_y" value="0.01" />     <!-- y length (m) -->
     <xacro:property name="coxa_kp" value="1000.0" />  <!-- contact stiffness -->
     <xacro:property name="coxa_kd" value="1000.0" />  <!-- contact damping -->
     <xacro:property name="coxa_mu1" value="10.0" />   <!-- friction coef 1 -->
@@ -30,8 +30,8 @@
         value="${pcb_density * (coxa_x * coxa_y * pcb_thickness_z)}" />  <!-- (kg) -->
 
     <!-- Femur (Leg Link 1) Properties -->
-    <xacro:property name="leg_link_1_x" value="0.02" />     <!-- x length (m) -->
-    <xacro:property name="leg_link_1_y" value="0.03" />     <!-- y length (m) -->
+    <xacro:property name="leg_link_1_x" value="0.01" />     <!-- x length (m) -->
+    <xacro:property name="leg_link_1_y" value="0.05" />     <!-- y length (m) -->
     <xacro:property name="leg_link_1_kp" value="1000.0" />  <!-- contact stiffness -->
     <xacro:property name="leg_link_1_kd" value="1000.0" />  <!-- contact damping -->
     <xacro:property name="leg_link_1_mu1" value="10.0" />   <!-- friction coef 1 -->
@@ -40,8 +40,8 @@
         value="${pcb_density * (leg_link_1_x * leg_link_2_y * pcb_thickness_z)}" />  <!-- (kg) -->
 
     <!-- Tibia (Leg Link 2) Properties -->
-    <xacro:property name="leg_link_2_x" value="0.02" />     <!-- x length (m) -->
-    <xacro:property name="leg_link_2_y" value="0.03" />     <!-- y length (m) -->
+    <xacro:property name="leg_link_2_x" value="0.05" />     <!-- x length (m) -->
+    <xacro:property name="leg_link_2_y" value="0.01" />     <!-- y length (m) -->
     <xacro:property name="leg_link_2_kp" value="1000.0" />  <!-- contact stiffness -->
     <xacro:property name="leg_link_2_kd" value="1000.0" />  <!-- contact damping -->
     <xacro:property name="leg_link_2_mu1" value="10.0" />   <!-- friction coef 1 -->
@@ -50,8 +50,8 @@
         value="${pcb_density * (leg_link_2_x * leg_link_2_y * pcb_thickness_z)}" />  <!-- (kg) -->
 
     <!-- Tarsus (Leg Link 3) Properties -->
-    <xacro:property name="leg_link_3_x" value="0.02" />     <!-- x length (m) -->
-    <xacro:property name="leg_link_3_y" value="0.03" />     <!-- y length (m) -->
+    <xacro:property name="leg_link_3_x" value="0.01" />     <!-- x length (m) -->
+    <xacro:property name="leg_link_3_y" value="0.05" />     <!-- y length (m) -->
     <xacro:property name="leg_link_3_kp" value="1000.0" />  <!-- contact stiffness -->
     <xacro:property name="leg_link_3_kd" value="1000.0" />  <!-- contact damping -->
     <xacro:property name="leg_link_3_mu1" value="10.0" />   <!-- friction coef 1 -->
@@ -60,8 +60,8 @@
         value="${pcb_density * (leg_link_3_x * leg_link_3_y * pcb_thickness_z)}" />  <!-- (kg) -->
         
     <!-- Joint Link Properties -->
-    <xacro:property name="joint_link_r" value="${pcb_thickness_z / 2}" />  <!-- radius (m) -->
-    <xacro:property name="joint_link_l" value="${leg_link_x}" />           <!-- length (m) -->
+    <xacro:property name="joint_link_r" value="0.0015" />  <!-- radius (m) -->
+    <xacro:property name="joint_link_l" value="0.01" />    <!-- length (m) -->
 
     <!-- Revolute Joint Properties -->
     <xacro:property name="joint_upper_limit" value="1.5708" />   <!-- (rad) -->
@@ -134,74 +134,102 @@
         </joint>
     </xacro:macro>
 
+    <!-- Coxa Definition -->
+    <xacro:macro name="millihex_coxa" params="leg_number color">
+
+        <!-- Coxa Geometry -->
+        <link name="leg${leg_number}_coxa">
+            <inertial>
+                <origin xyz="0 0 ${pcb_thickness_z / 2}" rpy="0 0 0" />
+                <mass value="${coxa_mass}" />
+                <xacro:box_inertia mass="${coxa_mass}" x="${coxa_x}"
+                    y="${coxa_y}" z="${pcb_thickness_z}" />
+            </inertial>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="${coxa_x} ${coxa_y} ${pcb_thickness_z}" />
+                </geometry>
+            </collision>
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="${coxa_x} ${coxa_y} ${pcb_thickness_z}" />
+                </geometry>
+                <material name="${color}"/>
+            </visual>
+        </link>
+
+        <!-- Gazebo properties -->
+        <gazebo reference="leg${leg_number}_coxa">
+            <kp>${coxa_kp}</kp>
+            <kd>${coxa_kd}</kd>
+            <mu1>${coxa_mu1}</mu1>
+            <mu2>${coxa_mu2}</mu2>
+            <material>Gazebo/${color}</material>
+        </gazebo>
+    </xacro:macro>
+
+    <!-- Femur (Leg Link 1) Definition -->
+    <xacro:macro name="millihex_leg_link_1" params="leg_number color">
+
+        <!-- Femur (Leg Link 1) Geometry -->
+        <link name="leg${leg_number}_link1">
+            <inertial>
+                <origin xyz="0 0 ${pcb_thickness_z / 2}" rpy="0 0 0" />
+                <mass value="${leg_link_1_mass}" />
+                <xacro:box_inertia mass="${leg_link_1_mass}" x="${leg_link_1_x}"
+                    y="${leg_link_1_y}" z="${pcb_thickness_z}" />
+            </inertial>
+            <collision>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="${leg_link_1_x} ${leg_link_1_y} ${pcb_thickness_z}" />
+                </geometry>
+            </collision>
+            <visual>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+                <geometry>
+                    <box size="${leg_link_1_x} ${leg_link_1_y} ${pcb_thickness_z}" />
+                </geometry>
+                <material name="${color}"/>
+            </visual>
+        </link>
+
+        <!-- Gazebo properties -->
+        <gazebo reference="leg${leg_number}_link1">
+            <kp>${leg_link_1_kp}</kp>
+            <kd>${leg_link_1_kd}</kd>
+            <mu1>${leg_link_1_mu1}</mu1>
+            <mu2>${leg_link_1_mu2}</mu2>
+            <material>Gazebo/${color}</material>
+        </gazebo>
+    </xacro:macro>
 
     <!-- Joint Link Definition -->
     <xacro:macro name="millihex_joint_link" params="leg_number link_number color">
         <!-- Joint Link Geometry -->
         <link name="leg${leg_number}_joint_link${link_number}">
             <collision>
-                <origin xyz="-${x_length / 2} -${y_length / 2} 0" rpy="0 0 0" />
+                <origin xyz="0 0 0" rpy="0 0 0" />
                 <geometry>
-                    <cylinder radius="${fake_joint_link_r}"
-                        length="${fake_joint_link_l}" />
+                    <cylinder radius="${joint_link_r}" length="${joint_link_l}" />
                 </geometry>
             </collision>
             <visual>
-                <origin xyz="-${x_length / 2} -${y_length / 2} 0" rpy="0 0 0" />
+                <origin xyz="0 0 0" rpy="0 0 0" />
                 <geometry>
-                    <box size="${x_length} ${y_length} ${pcb_thickness_z}" />
+                    <cylinder radius="${joint_link_r}" length="${joint_link_l}" />
                 </geometry>
                 <material name="${color}"/>
             </visual>
         </link>
 
         <!-- Gazebo properties -->
-        <gazebo reference="leg${leg_number}_link${link_number}">
-            <kp>${link_kp}</kp>
-            <kd>${link_kd}</kd>
-            <mu1>${link_mu1}</mu1>
-            <mu2>${link_mu2}</mu2>
+        <gazebo reference="leg${leg_number}_joint_link${link_number}">
             <material>Gazebo/${color}</material>
         </gazebo>
     </xacro:macro>
-
-
-    <!-- Leg Link Definition -->
-    <xacro:macro name="millihex_leg_link"
-        params="leg_number link_number x_length y_length color">
-        <!-- Leg Link Geometry -->
-        <link name="leg${leg_number}_link${link_number}">
-            <inertial>
-                <origin xyz="0 0 ${pcb_thickness_z / 2}" rpy="0 0 0" />
-                <mass value="${leg_link_mass}" />
-                <xacro:box_inertia mass="${leg_link_mass}" x="${x_length}"
-                    y="${y_length}" z="${pcb_thickness_z}" />
-            </inertial>
-            <collision>
-                <origin xyz="-${x_length / 2} -${y_length / 2} 0" rpy="0 0 0" />
-                <geometry>
-                    <box size="${x_length} ${y_length} ${pcb_thickness_z}" />
-                </geometry>
-            </collision>
-            <visual>
-                <origin xyz="-${x_length / 2} -${y_length / 2} 0" rpy="0 0 0" />
-                <geometry>
-                    <box size="${x_length} ${y_length} ${pcb_thickness_z}" />
-                </geometry>
-                <material name="${color}"/>
-            </visual>
-        </link>
-
-        <!-- Gazebo properties -->
-        <gazebo reference="leg${leg_number}_link${link_number}">
-            <kp>${link_kp}</kp>
-            <kd>${link_kd}</kd>
-            <mu1>${link_mu1}</mu1>
-            <mu2>${link_mu2}</mu2>
-            <material>Gazebo/${color}</material>
-        </gazebo>
-    </xacro:macro>
-
 
     <!-- Leg Joint Transmission -->
     <xacro:macro name="leg_transmission" params="leg_number joint_number">
@@ -220,7 +248,6 @@
             </actuator>
         </transmission>
     </xacro:macro>
-
   
     <!-- Assemble Leg -->
     <xacro:macro name="millihex_leg" params="leg_number">
@@ -243,16 +270,13 @@
                    velocity="${joint_velocity_limit}" />
             <axis xyz="1 0 0" />
         </joint>
-
         <xacro:leg_transmission leg_number="${leg_number}" joint_number="1" />
-
     </xacro:macro>
-
 
     <!-- Assemble Body -->
     <xacro:macro name="millihex_body" params="">
-        <!-- Call Torso xacro -->
-        <xacro:millihex_torso color="Orange" />
+        <!-- Call Thorax xacro -->
+        <xacro:millihex_thorax color="Orange" />
 
         <!-- Leg 1-->
         <xacro:millihex_leg leg_number="1" />
@@ -262,9 +286,7 @@
             <child link="leg1_link0" />
             <origin xyz="${torso_x / 2} -${torso_y / 2} 0" rpy="0 0 0" />
         </joint>
-    
     </xacro:macro>
-
 
     <!-- Add Gazebo Control Library -->
     <xacro:macro name="millihex_control" params="namespace">
@@ -274,7 +296,6 @@
             </plugin>
         </gazebo>
     </xacro:macro>
-  
 
     <!-- Build Robot and Gazebo Control Library -->
     <xacro:millihex_body />

--- a/robot/millihex_description.xacro
+++ b/robot/millihex_description.xacro
@@ -4,6 +4,14 @@
 <!-- rosrun xacro xacro millihex_description.xacro > millihex_description.urdf -->
 
 <robot name="millihex" xmlns:xacro="http://www.ros.org/wiki/xacro">
+    <!-- Gazebo Control Library -->
+    <xacro:macro name="millihex_control" params="namespace">
+        <gazebo>
+            <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
+                <robotNamespace>/${namespace}</robotNamespace>
+            </plugin>
+        </gazebo>
+    </xacro:macro>
 
     <!-- PCB Properties -->
     <xacro:property name="pcb_density" value="1850" />       <!-- FR4 density (kg/m^3) -->
@@ -58,6 +66,14 @@
     <xacro:property name="leg_link_3_mu2" value="10.0" />   <!-- friction coef 2 -->
     <xacro:property name="leg_link_3_mass"
         value="${pcb_density * (leg_link_3_x * leg_link_3_y * pcb_thickness_z)}" />  <!-- (kg) -->
+
+    <!-- Thorax Leg Joint Attachment Positions -->
+    <xacro:property name="leg_spacing" value="${(2 * coxa_x) + leg_link_2_x}" />
+    <xacro:property name="frontal_leg_x" value="${(thorax_x / 2) - (coxa_x / 2)}" />
+    <xacro:property name="medial_leg_x" value="${frontal_leg_x - leg_spacing}" />
+    <xacro:property name="hind_leg_x" value="${medial_leg_x - leg_spacing}" />
+    <xacro:property name="right_side_y" value="${thorax_y / 2}" />
+    <xacro:property name="left_side_y" value="${-(thorax_y / 2)}" />
         
     <!-- Joint Link Properties -->
     <xacro:property name="joint_link_r" value="0.0015" />  <!-- radius (m) -->
@@ -82,7 +98,6 @@
         <color rgba="0.98 0.41 0.055 1.0" />
     </material>
 
-    <!-- Equation Macros -->
     <!-- Calculate Moment of Inertia of a Box -->
     <xacro:macro name="box_inertia" params="mass x y z">
         <inertia ixx="${mass*(y*y+z*z)/12}" ixy = "0" ixz = "0"
@@ -91,7 +106,6 @@
 
     <!-- Thorax Definition -->
     <xacro:macro name="millihex_thorax" params="color">
-    
         <!-- Dummy Base Link to support KDL -->
         <link name="base_link" />
         
@@ -136,7 +150,6 @@
 
     <!-- Coxa Definition -->
     <xacro:macro name="millihex_coxa" params="leg_number color">
-
         <!-- Coxa Geometry -->
         <link name="leg${leg_number}_coxa">
             <inertial>
@@ -172,7 +185,6 @@
 
     <!-- Femur (Leg Link 1) Definition -->
     <xacro:macro name="millihex_leg_link_1" params="leg_number color">
-
         <!-- Femur (Leg Link 1) Geometry -->
         <link name="leg${leg_number}_link1">
             <inertial>
@@ -231,7 +243,7 @@
         </gazebo>
     </xacro:macro>
 
-    <!-- Leg Joint Transmission -->
+    <!-- Joint Transmission -->
     <xacro:macro name="leg_transmission" params="leg_number joint_number">
         <transmission name="leg${leg_number}_joint${joint_number}_tran">
             <type>transmission_interface/SimpleTransmission</type>
@@ -251,18 +263,15 @@
   
     <!-- Assemble Leg -->
     <xacro:macro name="millihex_leg" params="leg_number">
-        <!-- Link 0 (shoulder link), horizontally oriented -->
-        <xacro:millihex_leg_link leg_number="${leg_number}" link_number="0"
-            x_length="${leg_link_x}" y_length="${leg_link_y}" color="Black" />
+        <!-- Coxa -->
+        <xacro:millihex_coxa leg_number="${leg_number}" color="Black" />
 
-        <!-- Link 1, vertically oriented -->
-        <xacro:millihex_leg_link leg_number="${leg_number}" link_number="1"
-            x_length="${leg_link_y}" y_length="${leg_link_x}" color="Orange" />
-
+        <!-- Coxa to Femur Joint Link (Joint Link 1) -->
+        <xacro:millihex_joint_link leg_number="${leg_number}" link_number="1" color="Cyan" />
+        <!-- leg#_joint1 -->
         <joint name="leg${leg_number}_joint1" type="revolute">
-            <parent link="leg${leg_number}_link0" />
-            <child link="leg${leg_number}_link1" />
-            <origin xyz="0 -${leg_link_y} 0" rpy="0 0 0" />
+            <parent link="leg${leg_number}_coxa" />
+            <child link="leg${leg_number}_joint_link1" />
             <dynamics damping="${joint_damping}" friction="${joint_friction}" />
             <limit lower="${joint_lower_limit}"
                    upper="${joint_upper_limit}"
@@ -271,33 +280,32 @@
             <axis xyz="1 0 0" />
         </joint>
         <xacro:leg_transmission leg_number="${leg_number}" joint_number="1" />
+
+        <!-- Femur (Leg Link 1) -->
+        <xacro:millihex_leg_link_1 leg_number="${leg_number}" color="Orange" />
+        <!-- leg#_fixed_joint1 -->
+        <joint name="leg${leg_number}_fixed_joint1" type="fixed">
+            <parent link="leg${leg_number}_joint_link1" />
+            <child link="leg${leg_number}_link1" />
+            <origin xyz="0 0 0" rpy="0 0 0" />
+        </joint>
     </xacro:macro>
 
     <!-- Assemble Body -->
     <xacro:macro name="millihex_body" params="">
-        <!-- Call Thorax xacro -->
+        <!-- Thorax -->
         <xacro:millihex_thorax color="Orange" />
 
-        <!-- Leg 1-->
+        <!-- Leg 1 -->
         <xacro:millihex_leg leg_number="1" />
-        <!-- Leg 1, Joint 0 (fixed, shoulder joint)-->
-        <joint name="leg1_joint0" type="fixed">
-            <parent link="torso" />
-            <child link="leg1_link0" />
-            <origin xyz="${torso_x / 2} -${torso_y / 2} 0" rpy="0 0 0" />
+        <joint name="leg1_coxa_joint" type="fixed">
+            <parent link="thorax" />
+            <child link="leg1_coxa" />
+            <origin xyz="${frontal_leg_x} ${right_side_y} 0" rpy="0 0 0" />
         </joint>
     </xacro:macro>
 
-    <!-- Add Gazebo Control Library -->
-    <xacro:macro name="millihex_control" params="namespace">
-        <gazebo>
-            <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
-                <robotNamespace>/${namespace}</robotNamespace>
-            </plugin>
-        </gazebo>
-    </xacro:macro>
-
-    <!-- Build Robot and Gazebo Control Library -->
+    <!-- Assemble Robot -->
     <xacro:millihex_body />
     <xacro:millihex_control namespace="millihex" />
 

--- a/robot/millihex_description.xacro
+++ b/robot/millihex_description.xacro
@@ -72,8 +72,8 @@
     <xacro:property name="frontal_leg_x" value="${(thorax_x / 2) - (coxa_x / 2)}" />
     <xacro:property name="medial_leg_x" value="${frontal_leg_x - leg_spacing}" />
     <xacro:property name="hind_leg_x" value="${medial_leg_x - leg_spacing}" />
-    <xacro:property name="right_side_y" value="${thorax_y / 2}" />
-    <xacro:property name="left_side_y" value="${-(thorax_y / 2)}" />
+    <xacro:property name="right_side_y" value="${(thorax_y / 2) + (coxa_y / 2)}" />
+    <xacro:property name="left_side_y" value="${-((thorax_y / 2) + (coxa_y / 2))}" />
         
     <!-- Joint Link Properties -->
     <xacro:property name="joint_link_r" value="0.0015" />  <!-- radius (m) -->
@@ -88,14 +88,14 @@
     <xacro:property name="joint_friction" value="0.0" />         <!-- friction (N*m) -->
 
     <!-- Color Definitions -->
-    <material name="Cyan">
-        <color rgba="0.0 1.0 1.0 1.0" />
-    </material>
     <material name="Black">
         <color rgba="0.0 0.0 0.0 1.0" />
     </material>
     <material name="Orange">
         <color rgba="0.98 0.41 0.055 1.0" />
+    </material>
+    <material name="White">
+        <color rgba="0.0 0.0 0.0 0.0" />
     </material>
 
     <!-- Calculate Moment of Inertia of a Box -->
@@ -219,7 +219,8 @@
     </xacro:macro>
 
     <!-- Joint Link Definition -->
-    <xacro:macro name="millihex_joint_link" params="leg_number link_number color">
+    <xacro:macro name="millihex_joint_link"
+        params="leg_number link_number yaw color">
         <!-- Joint Link Geometry -->
         <link name="leg${leg_number}_joint_link${link_number}">
             <collision>
@@ -229,7 +230,7 @@
                 </geometry>
             </collision>
             <visual>
-                <origin xyz="0 0 0" rpy="0 0 0" />
+                <origin xyz="0 0 0" rpy="0 ${pi / 2} ${yaw}" />
                 <geometry>
                     <cylinder radius="${joint_link_r}" length="${joint_link_l}" />
                 </geometry>
@@ -267,11 +268,13 @@
         <xacro:millihex_coxa leg_number="${leg_number}" color="Black" />
 
         <!-- Coxa to Femur Joint Link (Joint Link 1) -->
-        <xacro:millihex_joint_link leg_number="${leg_number}" link_number="1" color="Cyan" />
+        <xacro:millihex_joint_link leg_number="${leg_number}" link_number="1"
+            yaw="0.0" color="White" />
         <!-- leg#_joint1 -->
         <joint name="leg${leg_number}_joint1" type="revolute">
             <parent link="leg${leg_number}_coxa" />
             <child link="leg${leg_number}_joint_link1" />
+            <origin xyz="0 ${(coxa_y / 2) + (joint_link_r)} 0" rpy="0 0 0" />
             <dynamics damping="${joint_damping}" friction="${joint_friction}" />
             <limit lower="${joint_lower_limit}"
                    upper="${joint_upper_limit}"
@@ -287,7 +290,7 @@
         <joint name="leg${leg_number}_fixed_joint1" type="fixed">
             <parent link="leg${leg_number}_joint_link1" />
             <child link="leg${leg_number}_link1" />
-            <origin xyz="0 0 0" rpy="0 0 0" />
+            <origin xyz="0 ${(leg_link_1_y / 2) + (joint_link_r)} 0" rpy="0 0 0" />
         </joint>
     </xacro:macro>
 

--- a/robot/millihex_description.xacro
+++ b/robot/millihex_description.xacro
@@ -1,60 +1,86 @@
 <?xml version="1.0"?>
-<!-- Check URDF: -->
+
+<!-- Generate URDF: -->
 <!-- rosrun xacro xacro millihex_description.xacro > millihex_description.urdf -->
 
 <robot name="millihex" xmlns:xacro="http://www.ros.org/wiki/xacro">
-    <!-- Physical Properties -->
-    <!-- PCB density ~= FR4 density (kg/m^3) -->
-    <!-- PCB thickness (m) -->
-    <xacro:property name="pcb_density" value="1850" />
-    <xacro:property name="pcb_thickness_z" value="0.003" />
 
-    <!-- Torso Link x,y dimensions (m) and mass (kg) -->
-    <xacro:property name="torso_x" value="0.14" />
-    <xacro:property name="torso_y" value="0.04" />
-    <xacro:property name="torso_mass"
-        value="${pcb_density * torso_x * torso_y * pcb_thickness_z}" />
+    <!-- PCB Properties -->
+    <xacro:property name="pcb_density" value="1850" />       <!-- FR4 density (kg/m^3) -->
+    <xacro:property name="pcb_thickness_z" value="0.003" />  <!-- PCB thickness (m) -->
 
-    <!-- Leg Link x,y dimensions (m) and mass (kg) -->
-    <xacro:property name="leg_link_x" value="0.02" />
-    <xacro:property name="leg_link_y" value="0.03" />
-    <xacro:property name="leg_link_mass"
-        value="${pcb_density * leg_link_x * leg_link_y * pcb_thickness_z}" />
+    <!-- Thorax Properties -->
+    <xacro:property name="thorax_x" value="0.20" />     <!-- x length (m) -->
+    <xacro:property name="thorax_y" value="0.03" />     <!-- y length (m) -->
+    <xacro:property name="thorax_kp" value="1000.0" />  <!-- contact stiffness -->
+    <xacro:property name="thorax_kd" value="1000.0" />  <!-- contact damping -->
+    <xacro:property name="thorax_mu1" value="10.0" />   <!-- friction coef 1 -->
+    <xacro:property name="thorax_mu2" value="10.0" />   <!-- friction coef 2 -->
+    <xacro:property name="thorax_mass"
+        value="${pcb_density * (thorax_x * thorax_y * pcb_thickness_z)}" />  <!-- (kg) -->
+    
+    <!-- Coxa Properties -->
+    <xacro:property name="coxa_x" value="0.14" />     <!-- x length (m) -->
+    <xacro:property name="coxa_y" value="0.04" />     <!-- y length (m) -->
+    <xacro:property name="coxa_kp" value="1000.0" />  <!-- contact stiffness -->
+    <xacro:property name="coxa_kd" value="1000.0" />  <!-- contact damping -->
+    <xacro:property name="coxa_mu1" value="10.0" />   <!-- friction coef 1 -->
+    <xacro:property name="coxa_mu2" value="10.0" />   <!-- friction coef 2 -->
+    <xacro:property name="coxa_mass"
+        value="${pcb_density * (coxa_x * coxa_y * pcb_thickness_z)}" />  <!-- (kg) -->
 
-    <!-- Fake Joint Link r,l dimensions (m) -->
-    <xacro:property name="fake_joint_link_r" value="${pcb_thickness_z / 2}" />
-    <xacro:property name="fake_joint_link_l" value="${leg_link_x}" />
+    <!-- Femur (Leg Link 1) Properties -->
+    <xacro:property name="leg_link_1_x" value="0.02" />     <!-- x length (m) -->
+    <xacro:property name="leg_link_1_y" value="0.03" />     <!-- y length (m) -->
+    <xacro:property name="leg_link_1_kp" value="1000.0" />  <!-- contact stiffness -->
+    <xacro:property name="leg_link_1_kd" value="1000.0" />  <!-- contact damping -->
+    <xacro:property name="leg_link_1_mu1" value="10.0" />   <!-- friction coef 1 -->
+    <xacro:property name="leg_link_1_mu2" value="10.0" />   <!-- friction coef 2 -->
+    <xacro:property name="leg_link_1_mass"
+        value="${pcb_density * (leg_link_1_x * leg_link_2_y * pcb_thickness_z)}" />  <!-- (kg) -->
 
-    <!-- Joint limits (rad) -->
-    <xacro:property name="joint_upper_limit" value="1.5708" />
-    <xacro:property name="joint_lower_limit" value="-1.5708" />
-    <xacro:property name="joint_effort_limit" value="0.01" />
-    <xacro:property name="joint_velocity_limit" value="0.01" />
+    <!-- Tibia (Leg Link 2) Properties -->
+    <xacro:property name="leg_link_2_x" value="0.02" />     <!-- x length (m) -->
+    <xacro:property name="leg_link_2_y" value="0.03" />     <!-- y length (m) -->
+    <xacro:property name="leg_link_2_kp" value="1000.0" />  <!-- contact stiffness -->
+    <xacro:property name="leg_link_2_kd" value="1000.0" />  <!-- contact damping -->
+    <xacro:property name="leg_link_2_mu1" value="10.0" />   <!-- friction coef 1 -->
+    <xacro:property name="leg_link_2_mu2" value="10.0" />   <!-- friction coef 2 -->
+    <xacro:property name="leg_link_2_mass"
+        value="${pcb_density * (leg_link_2_x * leg_link_2_y * pcb_thickness_z)}" />  <!-- (kg) -->
 
-    <!-- Joint damping (N*m*s/rad) and friction (N*m) -->
-    <xacro:property name="joint_damping" value="0.00003" />
-    <xacro:property name="joint_friction" value="0.001" />
+    <!-- Tarsus (Leg Link 3) Properties -->
+    <xacro:property name="leg_link_3_x" value="0.02" />     <!-- x length (m) -->
+    <xacro:property name="leg_link_3_y" value="0.03" />     <!-- y length (m) -->
+    <xacro:property name="leg_link_3_kp" value="1000.0" />  <!-- contact stiffness -->
+    <xacro:property name="leg_link_3_kd" value="1000.0" />  <!-- contact damping -->
+    <xacro:property name="leg_link_3_mu1" value="10.0" />   <!-- friction coef 1 -->
+    <xacro:property name="leg_link_3_mu2" value="10.0" />   <!-- friction coef 2 -->
+    <xacro:property name="leg_link_3_mass"
+        value="${pcb_density * (leg_link_3_x * leg_link_3_y * pcb_thickness_z)}" />  <!-- (kg) -->
+        
+    <!-- Joint Link Properties -->
+    <xacro:property name="joint_link_r" value="${pcb_thickness_z / 2}" />  <!-- radius (m) -->
+    <xacro:property name="joint_link_l" value="${leg_link_x}" />           <!-- length (m) -->
 
-    <!-- Gazebo Properties -->
-    <!-- Link contact stiffness (kp) -->
-    <!-- Link contact damping (kp) -->
-    <xacro:property name="link_kp" value="1000.0" />
-    <xacro:property name="link_kd" value="1000.0" />
-
-    <!-- Link coulomb friction coefficients in direction 1,2 -->
-    <!-- mu = [0, inf] where higher mu means less slip -->
-    <xacro:property name="link_mu1" value="10.0" />
-    <xacro:property name="link_mu2" value="10.0" />
-
+    <!-- Revolute Joint Properties -->
+    <xacro:property name="joint_upper_limit" value="1.5708" />   <!-- (rad) -->
+    <xacro:property name="joint_lower_limit" value="-1.5708" />  <!-- (rad) -->
+    <xacro:property name="joint_effort_limit" value="0.1" />     <!-- (rad/s) -->
+    <xacro:property name="joint_velocity_limit" value="0.1" />   <!-- (rad/s) -->
+    <xacro:property name="joint_damping" value="0.0" />          <!-- damping (N*m*s/rad)-->
+    <xacro:property name="joint_friction" value="0.0" />         <!-- friction (N*m) -->
 
     <!-- Color Definitions -->
+    <material name="Cyan">
+        <color rgba="0.0 1.0 1.0 1.0" />
+    </material>
     <material name="Black">
-        <color rgba="0 0 0 1" />
+        <color rgba="0.0 0.0 0.0 1.0" />
     </material>
     <material name="Orange">
-        <color rgba="0.98 0.41 0.055 1" />
+        <color rgba="0.98 0.41 0.055 1.0" />
     </material>
-
 
     <!-- Equation Macros -->
     <!-- Calculate Moment of Inertia of a Box -->
@@ -63,58 +89,56 @@
             iyy="${mass*(x*x+z*z)/12}" iyz = "0" izz="${mass*(x*x+y*y)/12}" />
     </xacro:macro>
 
-
-    <!-- Torso Definition -->
-    <xacro:macro name="millihex_torso" params="color">
+    <!-- Thorax Definition -->
+    <xacro:macro name="millihex_thorax" params="color">
+    
         <!-- Dummy Base Link to support KDL -->
         <link name="base_link" />
-
-        <!-- Torso Geometry -->
-        <link name="torso">
+        
+        <!-- Thorax Geometry -->
+        <link name="thorax">
             <inertial>
                 <origin xyz="0 0 ${pcb_thickness_z / 2}" rpy="0 0 0" />
-                <mass value="${torso_mass}" />
-                <xacro:box_inertia mass="${torso_mass}" x="${torso_x}"
-                    y="${torso_y}" z="${pcb_thickness_z}" />
+                <mass value="${thorax_mass}" />
+                <xacro:box_inertia mass="${thorax_mass}" x="${thorax_x}"
+                    y="${thorax_y}" z="${pcb_thickness_z}" />
             </inertial>
             <collision>
                 <origin xyz="0 0 0" rpy="0 0 0" />
                 <geometry>
-                    <box size="${torso_x} ${torso_y} ${pcb_thickness_z}" />
+                    <box size="${thorax_x} ${thorax_y} ${pcb_thickness_z}" />
                 </geometry>
             </collision>
             <visual>
                 <origin xyz="0 0 0" rpy="0 0 0" />
                 <geometry>
-                    <box size="${torso_x} ${torso_y} ${pcb_thickness_z}" />
+                    <box size="${thorax_x} ${thorax_y} ${pcb_thickness_z}" />
                 </geometry>
                 <material name="${color}" />
             </visual>
         </link>
 
         <!-- Gazebo properties -->
-        <gazebo reference="torso">
-            <kp>${link_kp}</kp>
-            <kd>${link_kd}</kd>
-            <mu1>${link_mu1}</mu1>
-            <mu2>${link_mu2}</mu2>
+        <gazebo reference="thorax">
+            <kp>${thorax_kp}</kp>
+            <kd>${thorax_kd}</kd>
+            <mu1>${thorax_mu1}</mu1>
+            <mu2>${thorax_mu2}</mu2>
             <material>Gazebo/${color}</material>
         </gazebo>
 
-        <!-- Join Base Link and Torso -->
+        <!-- Join Base Link and Thorax -->
         <joint name="base_joint" type="fixed">
             <parent link="base_link" />
-            <child link="torso" />
+            <child link="thorax" />
         </joint>
     </xacro:macro>
 
 
-    <!-- Fake Joint Link Definition -->
-    <xacro:macro name="millihex_fake_joint_link"
-        params="leg_number link_number x_length y_length color">
-
-        <!-- Fake Joint Link Geometry -->
-        <link name="leg${leg_number}_link${link_number}">
+    <!-- Joint Link Definition -->
+    <xacro:macro name="millihex_joint_link" params="leg_number link_number color">
+        <!-- Joint Link Geometry -->
+        <link name="leg${leg_number}_joint_link${link_number}">
             <collision>
                 <origin xyz="-${x_length / 2} -${y_length / 2} 0" rpy="0 0 0" />
                 <geometry>
@@ -222,42 +246,6 @@
 
         <xacro:leg_transmission leg_number="${leg_number}" joint_number="1" />
 
-        <!-- Link 2, horizontally oriented -->
-        <xacro:millihex_leg_link leg_number="${leg_number}" link_number="2"
-            x_length="${leg_link_x}" y_length="${leg_link_y}" color="Black" />
-
-        <joint name="leg${leg_number}_joint2" type="revolute">
-            <parent link="leg${leg_number}_link1" />
-            <child link="leg${leg_number}_link2" />
-            <origin xyz="-${leg_link_y} 0 0" rpy="0 0 0" />
-            <dynamics damping="${joint_damping}" friction="${joint_friction}" />
-            <limit lower="${joint_lower_limit}"
-                   upper="${joint_upper_limit}"
-                   effort="${joint_effort_limit}"
-                   velocity="${joint_velocity_limit}" />
-            <axis xyz="0 -1 0" />
-        </joint>
-
-        <xacro:leg_transmission leg_number="${leg_number}" joint_number="2" />
-
-        <!-- Link 3, horizontally oriented -->
-        <xacro:millihex_leg_link leg_number="${leg_number}" link_number="3"
-            x_length="${leg_link_x}" y_length="${leg_link_y}" color="Orange" />
-
-        <joint name="leg${leg_number}_joint3" type="revolute">
-            <parent link="leg${leg_number}_link2" />
-            <child link="leg${leg_number}_link3" />
-            <origin xyz="0 -${leg_link_y} 0" rpy="0 0 0" />
-            <dynamics damping="${joint_damping}" friction="${joint_friction}" />
-            <limit lower="${joint_lower_limit}"
-                   upper="${joint_upper_limit}"
-                   effort="${joint_effort_limit}"
-                   velocity="${joint_velocity_limit}" />
-            <axis xyz="1 0 0" />
-        </joint>
-
-        <xacro:leg_transmission leg_number="${leg_number}" joint_number="3" />
-
     </xacro:macro>
 
 
@@ -273,53 +261,6 @@
             <parent link="torso" />
             <child link="leg1_link0" />
             <origin xyz="${torso_x / 2} -${torso_y / 2} 0" rpy="0 0 0" />
-        </joint>
-
-        <!-- Leg 2 -->
-        <xacro:millihex_leg leg_number="2" />
-        <!-- Leg 2, Joint 0 (fixed, shoulder joint) -->
-        <joint name="leg2_joint0" type="fixed">
-            <parent link="torso" />
-            <child link="leg2_link0" />
-            <origin xyz="${leg_link_x / 2} -${torso_y / 2} 0" rpy="0 0 0" />
-        </joint>
-
-        <!-- Leg 3 -->
-        <xacro:millihex_leg leg_number="3" />
-        <!-- Leg 3, Joint 0 (fixed, shoulder joint) -->
-        <joint name="leg3_joint0" type="fixed">
-            <parent link="torso" />
-            <child link="leg3_link0" />
-            <origin xyz="-${torso_x / 2 - leg_link_x} -${torso_y / 2} 0"
-                rpy="0 0 0" />
-        </joint>
-
-        <!-- Leg 4 -->
-        <xacro:millihex_leg leg_number="4" />
-        <!-- Leg 4, Joint 0 (fixed, shoulder joint) -->
-        <joint name="leg4_joint0" type="fixed">
-            <parent link="torso" />
-            <child link="leg4_link0" />
-            <origin xyz="${torso_x / 2} ${torso_y / 2} 0" rpy="3.1416 0 0" />
-        </joint>
-
-        <!-- Leg 5 -->
-        <xacro:millihex_leg leg_number="5" />
-        <!-- Leg 5, Joint 0 (fixed, shoulder joint) -->
-        <joint name="leg5_joint0" type="fixed">
-            <parent link="torso" />
-            <child link="leg5_link0" />
-            <origin xyz="${leg_link_x / 2} ${torso_y / 2} 0" rpy="3.1416 0 0" />
-        </joint>
-
-        <!-- Leg 6 -->
-        <xacro:millihex_leg leg_number="6" />
-        <!-- Leg 6, Joint 0 (fixed, shoulder joint) -->
-        <joint name="leg6_joint0" type="fixed">
-            <parent link="torso" />
-            <child link="leg6_link0" />
-            <origin xyz="-${torso_x / 2 - leg_link_x} ${torso_y / 2} 0"
-                rpy="3.1416 0 0" />
         </joint>
     
     </xacro:macro>


### PR DESCRIPTION
Rewriting the XACRO to make the robot bigger as a part of scaling up its inertial values. The XACRO property definitions will be made more modular so that each leg link can be customized in the future. There will also be added "fake" joints between each of the legs to prevent collision friction between the leg link joints. These fake joints will be massless and inertialess.